### PR TITLE
Add admin user initialization

### DIFF
--- a/charts/trento-server/charts/trento-web/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-web/templates/_helpers.tpl
@@ -95,4 +95,14 @@ Return or generate the grafana admin password
   {{- end -}}
 {{- end -}}
 
+{{- define "trento.web.adminPassword" -}}
+  {{ $secretName := (print (include "trento-web.fullname" .) "-secret") }}
+  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+  {{- if $secret -}}
+    {{- index $secret "data" "ADMIN_PASSWORD" -}}
+  {{- else -}}
+    {{- (randAlphaNum 8) | b64enc -}}
+  {{- end -}}
+{{- end -}}
+
 

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -77,10 +77,6 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-          - name: certs
-            mountPath: "/certs"
-            readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trento-server/charts/trento-web/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/secret.yaml
@@ -6,3 +6,5 @@ type: Opaque
 data:
   SECRET_KEY_BASE: {{ include "trento.web.secretKeyBase" . | quote }}
   SMTP_PASSWORD: {{ .Values.alerting.smtpPassword | b64enc | quote }}
+  ADMIN_USER: {{ .Values.adminUser.username | b64enc | quote}}
+  ADMIN_PASSWORD: {{ include "trento.web.adminPassword" . | quote }}

--- a/charts/trento-server/charts/trento-web/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/secret.yaml
@@ -7,4 +7,4 @@ data:
   SECRET_KEY_BASE: {{ include "trento.web.secretKeyBase" . | quote }}
   SMTP_PASSWORD: {{ .Values.alerting.smtpPassword | b64enc | quote }}
   ADMIN_USER: {{ .Values.adminUser.username | b64enc | quote}}
-  ADMIN_PASSWORD: {{ include "trento.web.adminPassword" . | quote }}
+  ADMIN_PASSWORD: {{- if .Values.adminUser.password }} {{ .Values.adminUser.password | b64enc | quote }}{{- else }} {{ include "trento.web.adminPassword" . | quote }}{{- end}}

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -22,6 +22,10 @@ alerting:
   smtpPassword: ""
   recipient: ""
 
+adminUser:
+  username: "admin"
+  password: ""
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Adds admin user to the init container and generate password if not provided.

Added the password prompt to the install-server script,
bonus: refactored the mandatory parameters prompt to ask again if the user input was invalid.

_Please ignore the failing CI which is due the version bump, we can safely squash and merge and avoid bumping the version till we do not release in IBS for the GA._