### PR TITLE
Suse delivery

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -11,6 +11,11 @@ on:
     types: [published]
   workflow_dispatch:
 
+env:
+  OBS_USER: ${{ secrets.OBS_USER }}
+  OBS_PASS: ${{ secrets.OBS_PASS }}
+  OBS_PROJECT: ${{ secrets.OBS_PROJECT}}
+
 jobs:
   test-helm-charts:
     runs-on: ubuntu-20.04
@@ -93,3 +98,40 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Version }}"
+
+  obs-commit:
+    needs: [test-helm-charts]
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    container:
+      image: ghcr.io/trento-project/continuous-delivery:master
+      env:
+        GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEST_FOLDER: "/tmp/osc_project"
+    strategy:
+      matrix:
+        charts: ["trento-server"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure OSC
+        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
+        # that is used to run osc commands
+        run: |
+          /scripts/init_osc_creds.sh
+          mkdir -p $HOME/.config/osc
+          cp /root/.config/osc/oscrc $HOME/.config/osc
+      - name: Commit on OBS
+        run: |
+          echo "Installing helm and yq to run the makefile"
+          ssl_verify=host zypper in -y helm wget
+          wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+          echo "Commiting ${{ matrix.charts }} for package ${{ matrix.charts }}-helm"
+          OBS_PACKAGE=$OBS_PROJECT/${{ matrix.charts }}-helm
+          osc checkout $OBS_PACKAGE -o $DEST_FOLDER
+          cp -r packaging/suse/${{ matrix.charts }}/* $DEST_FOLDER
+          cp -r charts/${{ matrix.charts }}/Chart.yaml $DEST_FOLDER
+          cd $DEST_FOLDER
+          make
+          osc ar
+          osc commit -m "New development version of ${{ matrix.charts }}-helm released"

--- a/packaging/suse/trento-server/Makefile
+++ b/packaging/suse/trento-server/Makefile
@@ -1,0 +1,32 @@
+NAME = trento-server
+
+default: verify-deps clean tar
+
+verify-deps:
+	@yq -V | grep -q "yq version 3." >/dev/null 2>&1 || ( echo "yq 3.x not found; see https://github.com/marketplace/actions/yq-portable-yaml-processor" && false )
+	@# For yq 3.x we need to get https://github.com/mikefarah/yq/issues/677 fixed
+	@# then use
+	@# yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' $(NAME)/values.yaml ../values-overwrite.yaml
+	@helm version | grep -q "Version" >/dev/null 2>&1 || ( echo "helm not found" && false )
+
+clean:
+	rm -f *.tar
+tar:
+	osc service disabledrun
+	tmpdir=$$(mktemp -d -p .) && \
+      pushd $$tmpdir && \
+      tar -xf ../$(NAME).tar && \
+	for patch in $$(find .. -maxdepth 1 -name '*.patch'|sort); do \
+	    echo "Applying patch $$patch"; \
+	    cat $$patch | patch --no-backup-if-mismatch -p1 -s -d $(NAME); \
+	done && \
+	if [ -f "../values-overwrite.yaml" ]; then \
+	    echo -e "$$(yq m -x $(NAME)/values.yaml ../values-overwrite.yaml)" > $(NAME)/values.yaml; \
+	fi && \
+	pushd $(NAME) && \
+	helm dependency update && \
+	popd && \
+	rm $(NAME)/Chart.yaml && \
+	tar -cf ../$(NAME).tar --xform 's,$(NAME)/,,' $(NAME)/* && \
+	popd && \
+	rm -rf $$tmpdir

--- a/packaging/suse/trento-server/_helmignore
+++ b/packaging/suse/trento-server/_helmignore
@@ -1,0 +1,4 @@
+/*helmignore
+/*.patch
+/Makefile
+/values-overwrite.yaml

--- a/packaging/suse/trento-server/_service
+++ b/packaging/suse/trento-server/_service
@@ -1,0 +1,16 @@
+<services>
+	<service name="tar_scm" mode="disabled">
+		<param name="url">https://github.com/trento-project/helm-charts.git</param>
+		<param name="scm">git</param>
+		<param name="filename">trento-server</param>
+		<param name="version">_none_</param>
+		<param name="include">templates</param>
+		<param name="include">charts</param>
+		<param name="include">values.yaml</param>
+    <param name="include">Chart.yaml</param>
+		<param name="subdir">charts/trento-server</param>
+		<param name="revision">main</param>
+		<param name="versionformat">@PARENT_TAG@</param>
+	</service>
+	<service mode="buildtime" name="kiwi_metainfo_helper"/>
+</services>

--- a/packaging/suse/trento-server/values-overwrite.yaml
+++ b/packaging/suse/trento-server/values-overwrite.yaml
@@ -1,0 +1,22 @@
+trento-web:
+  image:
+    repository: registry.suse.com/trento/trento-web
+    tag: latest
+
+trento-runner:
+  image:
+    repository: registry.suse.com/trento/trento-runner
+    tag: latest
+
+postgresql:
+  image:
+    registry: registry.suse.com
+    repository: trento/trento-db
+    tag: latest
+  persistence:
+    mountPath: /var/lib/postgresql/data
+  postgresqlDataDir: /var/lib/postgresql/data/trento
+  securityContext:
+    fsGroup: 26
+  containerSecurityContext:
+    runAsUser: 26


### PR DESCRIPTION
Include the `suse` delivery files. They are needed to ship in OBS.

Besides this, I have added a new extra step to publish the new version on OBS in every merged PR.
It would be published here: https://build.opensuse.org/package/show/devel:sap:trento:factory/trento-server-helm