### PR TITLE
Fix syntax error in gihtub ci file introduced in last PR

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           PACKAGE_NAME=${{ matrix.charts }}-helm
           CHANGES_FILE=${{ matrix.charts }}.changes
-          CHART_FOLDER=$FOLDER/${{ matrix.charts }
+          CHART_FOLDER=$FOLDER/${{ matrix.charts }}
           osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
           mv $CHANGES_FILE $CHART_FOLDER
           TAG=${{ steps.latest-tag.outputs.tag }}


### PR DESCRIPTION
Damn, for some reason GH doesn't notify fast enough if the CI had a syntax error...