### PR TITLE
Downgrade postgresql chart 10

### DIFF
--- a/charts/trento-server/Chart.lock
+++ b/charts/trento-server/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: '>0.0.0'
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 11.6.3
+  version: 10.16.2
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts/
   version: 15.1.3
 - name: grafana
   repository: https://grafana.github.io/helm-charts/
   version: 6.21.8
-digest: sha256:79da0da8387bfafc718a7e8e48bfee5d4b5157fda972519a5250ab26fc865d1b
-generated: "2022-06-08T12:19:49.022114542+02:00"
+digest: sha256:96c4ae757287a2119b5a2b681c22c0f1e933dae19e53f767ae2813e53d164e85
+generated: "2022-06-08T14:25:56.505066268+02:00"

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:1.0.2
-#!BuildTag: trento/trento-server:1.0.2-build%RELEASE%
+#!BuildTag: trento/trento-server:1.0.3
+#!BuildTag: trento/trento-server:1.0.3-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   - name: trento-web
@@ -17,7 +17,7 @@ dependencies:
     version: ">0.0.0"
     condition: trento-runner.enabled
   - name: postgresql
-    version: 11.x.x
+    version: 10.x.x
     repository: https://charts.bitnami.com/bitnami/
     condition: postgresql.enabled
   - name: prometheus


### PR DESCRIPTION
Upgrading the postgresql chart to 11.x.x breaks the upgrade process.
Getting back to `10.x.x` version stream to try to fix it.

```Error: UPGRADE FAILED: execution error at (trento-server/charts/postgresql/templates/secrets.yaml:17:24):```