### PR TITLE
Add basic script for support requests

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -200,3 +200,50 @@ jobs:
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: Commit on OBS
         run: cp -r $FOLDER/* . && /scripts/upload.sh
+
+  obs-commit-plugin:
+    needs: [test-helm-charts]
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    container:
+      image: ghcr.io/trento-project/continuous-delivery:master
+      env:
+        PACKAGE_NAME: trento-supportconfig-plugin
+        GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FOLDER: packaging/suse/trento-supportconfig-plugin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-tag
+        with:
+          semver_only: true
+          initial_version: 0.0.1
+      - name: Configure OSC
+        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
+        # that is used to run osc commands
+        run: |
+          /scripts/init_osc_creds.sh
+          mkdir -p $HOME/.config/osc
+          cp /root/.config/osc/oscrc $HOME/.config/osc
+      - name: Prepare .changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          CHANGES_FILE=$PACKAGE_NAME.changes
+          osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
+          mv $CHANGES_FILE $FOLDER
+          TAG=${{ steps.latest-tag.outputs.tag }}
+          hack/gh_release_to_obs_changeset.py ${{ github.repository }} -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
+
+      - name: prepare _service file
+        run: |
+          git config --global --add safe.directory /__w/helm-charts/helm-charts
+          # Using get_version_from_git script as it creates a more meaningful version string (tag+sha) which is interesting
+          # only for rpm packages
+          VERSION=$(./hack/get_version_from_git.sh)
+          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+      - name: Commit on OBS
+        run: cp -r $FOLDER/* . && /scripts/upload.sh

--- a/packaging/suse/trento-server-installer/trento-server-installer.spec
+++ b/packaging/suse/trento-server-installer/trento-server-installer.spec
@@ -52,10 +52,12 @@ install -D -m 0640 packaging/suse/config/installer.conf %{buildroot}%{_sysconfdi
 
 # Install the installer script.
 install -D -m 0755 scripts/install-server.sh "%{buildroot}%{_bindir}/install-trento-server"
+install -D -m 0755 scripts/trento-support.sh "%{buildroot}%{_bindir}/trento-support"
 
 %files
 %defattr(-,root,root)
 %{_bindir}/install-trento-server
+%{_bindir}/trento-support
 
 %if 0%{?suse_version} > 1500
 %dir %{_distconfdir}/trento

--- a/packaging/suse/trento-supportconfig-plugin/_service
+++ b/packaging/suse/trento-supportconfig-plugin/_service
@@ -1,0 +1,16 @@
+<services>
+    <service name="tar_scm" mode="disabled">
+        <param name="url">https://github.com/trento-project/helm-charts.git</param>
+        <param name="scm">git</param>
+        <param name="filename">trento-supportconfig-plugin</param>
+        <param name="revision">%%REVISION%%</param>
+        <param name="versionformat">%%VERSION%%</param>
+    </service>
+    <service name="set_version" mode="disabled">
+        <param name="file">trento-supportconfig-plugin.spec</param>
+    </service>
+    <service name="recompress" mode="disabled">
+        <param name="file">*.tar</param>
+        <param name="compression">gz</param>
+    </service>
+</services>

--- a/packaging/suse/trento-supportconfig-plugin/trento
+++ b/packaging/suse/trento-supportconfig-plugin/trento
@@ -1,0 +1,9 @@
+#!/bin/bash
+#############################################################
+# Name:        Supportconfig Plugin for SUSE trento
+# Description: Gathers important troubleshooting information
+#              about a SUSE trento SAP console
+# License:     GPLv2
+#############################################################
+
+trento-support --output stdout --collect all

--- a/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
+++ b/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
@@ -30,6 +30,7 @@ BuildArch: noarch
 Provides:  %{name} = %{version}-%{release}
 Requires:  supportconfig-plugin-resource
 Requires:  supportconfig-plugin-tag
+Requires:  trento-server-installer
 
 %description
 Supportconfig plugin for trento.

--- a/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
+++ b/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
@@ -30,6 +30,7 @@ BuildArch: noarch
 Provides:  %{name} = %{version}-%{release}
 Requires:  supportconfig-plugin-resource
 Requires:  supportconfig-plugin-tag
+Requires:  python3-yq
 Requires:  trento-server-installer
 
 %description

--- a/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
+++ b/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
@@ -1,0 +1,58 @@
+#
+# spec file for package trento-supportconfig-plugin
+#
+# Copyright (c) 2022 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative   .
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:      trento-supportconfig-plugin
+# Version will be processed via set_version source service
+Version:   0
+Release:   0
+License:   Apache-2.0
+Summary:   Supportconfig plugin for trento
+Group:     System/Monitoring
+URL:       https://github.com/trento-project/helm-charts
+Source:    %{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-build
+BuildArch: noarch
+Provides:  %{name} = %{version}-%{release}
+Requires:  supportconfig-plugin-resource
+Requires:  supportconfig-plugin-tag
+
+%description
+Supportconfig plugin for trento.
+
+The script allows the user to collect all relevant installation details for a support request.
+
+%prep
+%setup -q # unpack project sources
+
+%build
+
+%install
+pwd;ls -la
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins
+install -d $RPM_BUILD_ROOT/sbin
+install -m 0544 packaging/suse/trento-supportconfig-plugin/trento $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins
+
+%files
+%defattr(-,root,root)
+/usr/lib/supportconfig
+/usr/lib/supportconfig/plugins
+/usr/lib/supportconfig/plugins/trento
+
+%clean
+rm -rf $RPM_BUILD_ROOT

--- a/scripts/trento-support.sh
+++ b/scripts/trento-support.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+set -e
+
+readonly ARGS=("$@")
+declare -A VALID_FACILITIES=(
+    ["configuration"]="configuration"
+    ["base"]="base"
+    ["kubernetes"]="kubernetes"
+    ["all"]="all"
+)
+
+indent() { sed 's/^/  /'; }
+
+collect_trento_configuration() {
+    echo "===== TRENTO CONFIGURATION FILES ====="
+    echo "/etc/trento/installer.conf:"
+    echo "$(</etc/trento/installer.conf)"
+    echo "===== END TRENTO CONFIGURATION FILES ====="
+} &> "$OUTPUT"
+
+collect_base_system() {
+    echo "===== BASE SYSTEM DETAILS ====="
+    set -x
+    k3s --version
+    helm version
+    helm get all trento-server
+    set +x
+    echo "===== END BASE SYSTEM DETAILS ====="    
+} &> "$OUTPUT"
+
+collect_kubernetes_state() {
+    echo "===== KUBERNETES CLUSTER STATE ====="
+    set -x
+    kubectl get nodes -o wide
+    kubectl get pods
+    kubectl logs deploy/trento-server-runner
+    kubectl logs deploy/trento-server-web -c init
+    kubectl logs deploy/trento-server-web
+    kubectl describe deployments
+    crictl images
+    set +x
+    echo "===== END KUBERNETES CLUSTER STATE ====="
+} &> "$OUTPUT"
+
+collect_all() {
+    collect_trento_configuration
+    collect_base_system
+    collect_kubernetes_state    
+}
+
+generate_output() {
+    if [[ " ${arr[*]} " =~ "all" ]]; then
+        collect_all
+        exit 0
+    fi
+
+    if [[ " ${arr[*]} " =~ "configuration" ]]; then
+       collect_trento_configuration
+    fi
+
+    if [[ " ${arr[*]} " =~ "base" ]]; then
+        collect_base_system
+    fi
+
+    if [[ " ${arr[*]} " =~ "kubernetes" ]]; then
+        collect_kubernetes_state
+    fi
+
+    if [[ -n "$COMPRESS" ]]; then
+        echo "COMPRESSING OUTPUT"
+        tar -czf "$OUTPUT.tar.gz" "$OUTPUT"
+        rm -f "$OUTPUT"
+    fi
+}
+
+usage() {
+    echo "Usage: $0 --output [stdout|file|file-tgz] --collect [configuration|base|kubernetes|all]"
+}
+
+cmdline() {
+    # abort if we have less than 2 arguments
+    if [[ $# -lt 2 ]]; then
+        usage
+        exit 1
+    fi
+    local arg=
+
+    for arg; do
+        local delim=""
+        case "$arg" in
+        --help) args="${args}-h " ;;
+        --output) args="${args}-o " ;;
+        --collect) args="${args}-c " ;;
+
+        *)
+            [[ "${arg:0:1}" == "-" ]] || delim="\""
+            args="${args}${delim}${arg}${delim} "
+            ;;
+        esac
+    done
+
+    eval set -- "$args"
+
+    while getopts "ho:c:" OPTION; do
+        case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+
+        o)
+            OUTPUT_OPT=$OPTARG
+            if [[ $OUTPUT_OPT != "stdout" && $OUTPUT_OPT != "file" && $OUTPUT_OPT != "file-tgz" ]]; then
+                echo "Invalid output type: $OUTPUT_OPT"
+                usage
+                exit 1
+            fi
+
+            if [ "$OUTPUT_OPT" = "stdout" ]; then
+                OUTPUT="/dev/stdout"
+            elif [ "$OUTPUT_OPT" = "file-tgz" ]; then
+                OUTPUT="$(date +%Y-%m-%d_%H%M)_support.txt"
+                COMPRESS=true
+            else
+                OUTPUT="$(date +%Y-%m-%d_%H%M)_support.txt"
+            fi
+            ;;
+
+        c)
+            COLLECT=$OPTARG
+            IFS=, read -a arr <<<"${COLLECT}"            
+            for key in "${!arr[@]}"; do
+                if [[ -z "${VALID_FACILITIES[${arr[$key]}]}" ]]; then
+                    printf '%s: unsupported facility\n' "${arr[$key]}"
+                    usage
+                    exit 1
+                fi
+            done
+            ;;
+
+        *)
+            usage
+            exit 0
+            ;;
+        esac
+    done
+
+    return 0
+}
+
+cmdline "${ARGS[@]}"
+generate_output


### PR DESCRIPTION
Copy-paste from the old PR in `trento-project/web`:



This PR adds a support script that customers or our L3 team can call to collect data about the installation.

The base idea is to collect everything that might help us determine what could be going wrong on the trento-server installation.

Some random thoughts:

 - Do we need something on the agent side too for agent related issues? Not sure if it would make sense to have something that needs to be executed on each agent or if instead we can rely on trento-server to collect such information from here

 - It would be nice if we can integrate this with supportconfig used in SLES. This script should still remain here (for non-SLES users), but could write a very simple wrapper plugin for supportconfig that call this script to collect all that it needs. The only change we would need is that we'd have to output to STDOUT instead of a file (as IIRC, supportconfig plugins are expect to output to STDOUT)

Suggestions welcome!
