### PR TITLE
Change trento-premium-server-installer to be obsolete in the spec

### DIFF
--- a/packaging/suse/trento-server-installer/trento-server-installer.spec
+++ b/packaging/suse/trento-server-installer/trento-server-installer.spec
@@ -28,7 +28,8 @@ Source:    %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
 BuildArch: noarch
 Provides:  %{name} = %{version}-%{release}
-Conflicts: trento-premium-server-installer
+Provides:  trento-premium-server-installer = %{version}-%{release}
+Obsoletes: trento-premium-server-installer < 0.9.1-0
 
 %description
 Quickstart installer for the trento-server helm chart.


### PR DESCRIPTION
This PR simply changes the relationship with the old `trento-premium-server-installer` so that it's now marked as Obsolete. This should reduce the possibility of users installing the older package without noticing that it has been obsoleted.