### PR TITLE
Update grafana chart dependency to 6.36.1

### DIFF
--- a/charts/trento-server/Chart.lock
+++ b/charts/trento-server/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 15.1.3
 - name: grafana
   repository: https://grafana.github.io/helm-charts/
-  version: 6.21.8
-digest: sha256:96c4ae757287a2119b5a2b681c22c0f1e933dae19e53f767ae2813e53d164e85
-generated: "2022-07-07T16:11:12.757384952+02:00"
+  version: 6.36.3
+digest: sha256:00a51940599944d19bfb9c73e12d12ac5dd009bead1a507918488e0f752172d2
+generated: "2022-09-14T15:01:11.224040855+01:00"

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -25,6 +25,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts/
     condition: prometheus.enabled
   - name: grafana
-    version: ~6.21.2
+    version: ~6.36.1
     repository: https://grafana.github.io/helm-charts/
     condition: grafana.enabled

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:1.1.0
-#!BuildTag: trento/trento-server:1.1.0-build%RELEASE%
+#!BuildTag: trento/trento-server:1.1.1
+#!BuildTag: trento/trento-server:1.1.1-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.1.0
+version: 1.1.1
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:1.1.1
-#!BuildTag: trento/trento-server:1.1.1-build%RELEASE%
+#!BuildTag: trento/trento-server:1.1.1-dev
+#!BuildTag: trento/trento-server:1.1.1-dev+build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.1.1
+version: 1.1.1-dev
 
 dependencies:
   - name: trento-web


### PR DESCRIPTION
This should update the grafana helm chart that we use, fixing also the broken pipelines due to 1.25.x removing PodSecurityPolicy see  [this](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/)