### PR TITLE
Add basic rabbitmq chart

### DIFF
--- a/charts/trento-server/Chart.lock
+++ b/charts/trento-server/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts/
   version: 6.36.3
-digest: sha256:00a51940599944d19bfb9c73e12d12ac5dd009bead1a507918488e0f752172d2
-generated: "2022-09-14T15:01:11.224040855+01:00"
+- name: rabbitmq
+  repository: https://charts.bitnami.com/bitnami/
+  version: 10.3.9
+digest: sha256:c4bccf4b063296b73c47f23cfdf24eed572eb6cf5d94a8be4e020ddefda29564
+generated: "2022-10-10T14:54:10.104992787+02:00"

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.1.1-dev
+version: 1.1.1-dev.1
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -28,3 +28,7 @@ dependencies:
     version: ~6.36.1
     repository: https://grafana.github.io/helm-charts/
     condition: grafana.enabled
+  - name: rabbitmq
+    version: ~10.3.9
+    repository: https://charts.bitnami.com/bitnami/
+    condition: rabbitmq.enabled

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -14,6 +14,9 @@ global:
     name: grafana
   prometheus:
     name: prometheus-server
+  rabbitmq:
+    name: rabbitmq
+    servicePort: 5672
 
 ### Sub Charts Specific Values ###
 trento-web:
@@ -78,3 +81,11 @@ grafana:
       - ""
       ## Path for grafana ingress
     path: /grafana
+
+rabbitmq:
+  enabled: false
+  persistence:
+    enabled: true
+  auth:
+    username: trento
+    password: trento


### PR DESCRIPTION
Basic `rabbitmq` addition from bitnami using the default values (except the username and password): 
https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq/

It is disabled by default to not break current production state. 