### PR TITLE
Switch + sign for - in build metadata

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #!BuildTag: trento/trento-server:1.2.0
-#!BuildTag: trento/trento-server:1.2.0+build%RELEASE%
+#!BuildTag: trento/trento-server:1.2.0-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.


### PR DESCRIPTION
According to @mrueckert, we are using non-compliant characters in the build metadata. See: https://github.com/distribution/distribution/blob/main/reference/regexp.go#L66

This should fix this issue.