### PR TITLE
Bump postgresql chart version to 12.1.6

### DIFF
--- a/charts/trento-server/Chart.lock
+++ b/charts/trento-server/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: '>0.0.0'
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 10.16.2
+  version: 12.1.6
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts/
   version: 15.1.3
@@ -20,5 +20,5 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami/
   version: 10.3.9
-digest: sha256:95565267169f0cd0dc9d32ed690651c3310d2f1233781fe64fa5ad5292d760c7
-generated: "2022-10-13T14:14:59.942701776+01:00"
+digest: sha256:f8edc11797bde2fb06c316ef77f09fea7f0d62e43e434641b68f883f136cffc9
+generated: "2023-01-02T12:39:36.790666843+01:00"

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:1.2.0
-#!BuildTag: trento/trento-server:1.2.0-build%RELEASE%
+#!BuildTag: trento/trento-server:1.2.1
+#!BuildTag: trento/trento-server:1.2.1-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.0
+version: 1.2.1
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: ">0.0.0"
     condition: wanda.enabled
   - name: postgresql
-    version: 10.x.x
+    version: ~12.1.6
     repository: https://charts.bitnami.com/bitnami/
     condition: postgresql.enabled
   - name: prometheus


### PR DESCRIPTION
Bumps the chart version (not the container) since the version was too old and removed from the repository