### PR TITLE
Provision postgresql data folder permissions

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.2-dev2
+version: 1.2.2-dev3
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/templates/provision-database-permissions-job.yaml
+++ b/charts/trento-server/templates/provision-database-permissions-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-provision-database-permissions-job"
+spec:
+  template:
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data-{{ .Release.Name }}-postgresql-0
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.postgresql.postgresqlDataDir }}
+              chmod 700 {{ .Values.postgresql.postgresqlDataDir }}
+          securityContext: 
+            runAsUser: {{ .Values.postgresql.containerSecurityContext.runAsUser }}
+          volumeMounts:
+            {{- if .Values.postgresql.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.postgresql.persistence.mountPath }}
+              {{- if .Values.postgresql.persistence.subPath }}
+              subPath: {{ .Values.postgresql.persistence.subPath }}
+              {{- end }}
+            {{- end }}
+      restartPolicy: Never
+  backoffLimit: 4

--- a/charts/trento-server/templates/provision-database-permissions-job.yaml
+++ b/charts/trento-server/templates/provision-database-permissions-job.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-provision-database-permissions-job"
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       volumes:

--- a/charts/trento-server/templates/provision-database-permissions-job.yaml
+++ b/charts/trento-server/templates/provision-database-permissions-job.yaml
@@ -18,6 +18,7 @@ spec:
             - |
               mkdir -p {{ .Values.postgresql.postgresqlDataDir }}
               chmod 700 {{ .Values.postgresql.postgresqlDataDir }}
+              ls -la {{ .Values.postgresql.postgresqlDataDir }}
           securityContext: 
             runAsUser: {{ .Values.postgresql.containerSecurityContext.runAsUser }}
           volumeMounts:


### PR DESCRIPTION
Fix for the invalid permissions issue in the postgresql pod:

```
# kubectl logs trento-server-postgresql-0 -n suse-trento
2023-02-02 15:29:23.771 UTC [8]FATAL: data directory "/var/lib/postgresql/data/trento" has invalid permissions
2023-02-02 15:29:23.771 UTC [8]DETAIL: Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```
This job changes the folder permissions, so the next time the postgresql pod is started, it doesn't have this error.

Basically, it launches a container mounting the volume where the pg data is stored to change the folder permissions.

I have tested it with the community postgresql image, and with the trento-db image.

PD: In fact, if we use the official docker image or the bitnami postgresql docker image, both of them continue working, so at some point, we are ready to remove that in-house dependency and use 3rd party images