### PR TITLE
Add a temporary fix to wanda ingress path value to use versioning

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.2-dev3
+version: 1.2.2-dev4
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-dev1
+version: 0.1.0-dev2

--- a/charts/trento-server/charts/trento-wanda/values.yaml
+++ b/charts/trento-server/charts/trento-wanda/values.yaml
@@ -63,6 +63,8 @@ ingress:
       paths:
         - path: /api/checks
           pathType: ImplementationSpecific
+        - path: /api/v1/checks
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Temporary solution for the ingress and load balancer ambiguity.
Without this, the `/api/v1/...` are always redirected to the web container.
We will implement alongside this a more robust solution, using better namespaces for the services, so there is not any potential issue on this