### PR TITLE
Service namespacing

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.2-dev4
+version: 1.2.2-dev5
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-dev2
+version: 0.1.0-dev3

--- a/charts/trento-server/charts/trento-wanda/values.yaml
+++ b/charts/trento-server/charts/trento-wanda/values.yaml
@@ -61,9 +61,7 @@ ingress:
   hosts:
     - host: ""
       paths:
-        - path: /api/checks
-          pathType: ImplementationSpecific
-        - path: /api/v1/checks
+        - path: /check_service
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2-dev2
+version: 1.2.2-dev3

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   SMTP_SERVER: "{{ .Values.alerting.smtpServer }}"
   SMTP_PORT: "{{ .Values.alerting.smtpPort }}"
   SMTP_USER: "{{ .Values.alerting.smtpUser }}"
+  CHECKS_SERVICE_BASE_URL: "{{ .Values.global.checkServiceBaseUrl }}"
   SMTP_PASSWORD: "{{ .Values.alerting.smtpPassword }}"
   ALERT_SENDER: "{{ .Values.alerting.sender }}"
   ALERT_RECIPIENT: "{{ .Values.alerting.recipient }}"

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -4,6 +4,7 @@
 
 global:
   logLevel: info
+  checkServiceBaseUrl: "/check_service"
   trentoWeb:
     servicePort: ""
   postgresql:


### PR DESCRIPTION
Service namespacing.

The wanda service ingress will respond under the path "/checks_service", the web is configured to use that subpath as base url for the frontend client.

See: https://github.com/trento-project/web/pull/1198