### PR TITLE
Fix shared access token key usage

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.2-dev4
+version: 1.2.2-dev5
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-dev2
+version: 0.1.0-dev3

--- a/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
@@ -81,13 +81,3 @@ Return Trento Wanda service port
     {{- (randAlphaNum 64) | b64enc -}}
   {{- end -}}
 {{- end -}}
-
-{{- define "trento-wanda.accessTokenSecret" -}}
-  {{ $secretName := (print (include "trento-wanda.fullname" .) "-secret") }}
-  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
-  {{- if $secret -}}
-    {{- index $secret "data" "ACCESS_TOKEN_ENC_SECRET" -}}
-  {{- else -}}
-    {{- (randAlphaNum 64) | b64enc -}}
-  {{- end -}}
-{{- end -}}

--- a/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
                 name: {{ include "trento-wanda.fullname" . }}-configmap
             - secretRef:
                 name: {{ include "trento-wanda.fullname" . }}-secret
+            - secretRef:
+                name: {{ .Release.Name }}-auth-tokens-secret
           args: ['eval', 'Wanda.Release.init()']
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/trento-server/charts/trento-wanda/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/secret.yaml
@@ -5,4 +5,3 @@ metadata:
 type: Opaque
 data:
   SECRET_KEY_BASE: {{ include "trento-wanda.secretKeyBase" . | quote }}
-  ACCESS_TOKEN_ENC_SECRET: {{ include "trento-wanda.accessTokenSecret" . | quote }}

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2-dev2
+version: 1.2.2-dev3

--- a/charts/trento-server/charts/trento-web/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-web/templates/_helpers.tpl
@@ -77,7 +77,8 @@ Return or generate the grafana admin password
 */}}
 
 {{- define "trento.grafana.password" -}}
-  {{- $secret := (lookup "v1" "Secret" .Release.Namespace "trento-server-grafana-secret") -}}
+  {{- $secretName := (print .Release.Name "-grafana-secret") -}}
+  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
   {{- if $secret -}}
     {{- index $secret "data" "admin-password" -}}
   {{- else -}}
@@ -86,7 +87,7 @@ Return or generate the grafana admin password
 {{- end -}}
 
 {{- define "trento-web.accessTokenSecret" -}}
-  {{ $secretName := (print (include "trento-web.fullname" .) "-secret") }}
+  {{- $secretName := (print .Release.Name "-auth-tokens-secret") -}}
   {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
   {{- if $secret -}}
     {{- index $secret "data" "ACCESS_TOKEN_ENC_SECRET" -}}
@@ -96,7 +97,7 @@ Return or generate the grafana admin password
 {{- end -}}
 
 {{- define "trento-web.refreshTokenSecret" -}}
-  {{ $secretName := (print (include "trento-web.fullname" .) "-secret") }}
+  {{- $secretName := (print .Release.Name "-auth-tokens-secret") -}}
   {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
   {{- if $secret -}}
     {{- index $secret "data" "REFRESH_TOKEN_ENC_SECRET" -}}

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: GRAFANA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: trento-server-grafana-secret
+                  name: {{ .Release.Name }}-grafana-secret
                   key: admin-password
           args: ['eval', 'Trento.Release.init()']
       containers:
@@ -61,7 +61,7 @@ spec:
             - name: GRAFANA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: trento-server-grafana-secret
+                  name: {{ .Release.Name }}-grafana-secret
                   key: admin-password
           args:
             - start

--- a/charts/trento-server/charts/trento-web/templates/grafana-secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/grafana-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: trento-server-grafana-secret
+  name: {{ .Release.Name }}-grafana-secret
 type: Opaque
 data:
   admin-user: {{ "admin" | b64enc | quote }}

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -63,7 +63,7 @@ grafana:
   persistence:
     enabled: true
   admin:
-    existingSecret: trento-server-grafana-secret
+    existingSecret: "{{ .Release.Name }}-grafana-secret"
   grafana.ini:
     auth.anonymous:
       enabled: true


### PR DESCRIPTION
Fix shared jwt access token values usage.
There where some leftovers and some names wrong. This causes that the access token was being get empty, as the used secret name was not there.