### PR TITLE
Disable cors usage for wanda

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 1.2.2-dev5
+version: 1.2.2-dev6
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-dev3
+version: 0.1.0-dev4

--- a/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
@@ -81,3 +81,14 @@ Return Trento Wanda service port
     {{- (randAlphaNum 64) | b64enc -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Create CORS origin value
+*/}}
+{{- define "trentoWanda.cors_origin" -}}
+{{- if .Values.cors.origin }}
+    {{- .Values.cors.origin -}}
+{{- else -}}
+    {{- printf "http://%s-%s" .Release.Name .Values.global.trentoWanda.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
@@ -5,4 +5,7 @@ metadata:
 data:
   DATABASE_URL: "ecto://{{ .Values.global.postgresql.postgresqlUsername }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Release.Name }}-{{ .Values.global.postgresql.name }}/trento_wanda"
   AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
-  CORS_ENABLED: "false"
+  CORS_ENABLED: {{ .Values.cors.enabled | quote }}
+  {{- if .Values.cors.enabled }}
+  CORS_ORIGIN: {{ include "trentoWanda.cors_origin" . | quote }}
+  {{- end }}

--- a/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   DATABASE_URL: "ecto://{{ .Values.global.postgresql.postgresqlUsername }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Release.Name }}-{{ .Values.global.postgresql.name }}/trento_wanda"
   AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
-  CORS_ORIGIN: "http://{{ .Release.Name }}-{{ .Values.global.trentoWanda.name }}/api"
+  CORS_ENABLED: "false"

--- a/charts/trento-server/charts/trento-wanda/values.yaml
+++ b/charts/trento-server/charts/trento-wanda/values.yaml
@@ -12,6 +12,9 @@ global:
     name: postgresql
     servicePort: 5432
 
+cors:
+  enabled: false
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
As the web and wanda are running using the same domain, cors usage is not needed.

Depends on: https://github.com/trento-project/wanda/pull/206