### PR TITLE
Make pruning crobjob days variable

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.1.1
+version: 2.1.1-dev2
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.1-dev2

--- a/charts/trento-server/charts/trento-web/templates/prune-events-cronjob.yaml
+++ b/charts/trento-server/charts/trento-web/templates/prune-events-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ include "trento-web.fullname" . }}-prune-events-cronjob
 spec:
-  schedule: {{ .Values.pruneEventsCronjobSchedule }}
+  schedule: "{{ .Values.pruneEventsCronjobSchedule }}"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -19,5 +19,7 @@ spec:
                   name: {{ include "trento-web.fullname" . }}-configmap
               - secretRef:
                   name: {{ include "trento-web.fullname" . }}-secret
-            args: ['eval', 'Trento.Release.prune_events([])']
+              - secretRef:
+                  name: {{ .Release.Name }}-auth-tokens-secret
+            args: ['eval', 'Trento.Release.prune_events(["--days", "{{ .Values.pruneEventsOlderThan }}"])']
           restartPolicy: OnFailure

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -67,6 +67,7 @@ service:
   port: 4000
 
 pruneEventsCronjobSchedule: "0 0 * * *"
+pruneEventsOlderThan: 10
 
 ingress:
   enabled: true


### PR DESCRIPTION
Make the days flag for the pruning task variable, leaving the 10 days as default.
In fact, this change fixes a bug we had in the cronjob (which most probably was not being executed properly). An secrets env file was not being provided

The usage would be something like:
```
helm install trento-server . --set trento-web.pruneEventsOlderThan=0 --set trento-web.pruneEventsCronjobSchedule="* * * * *" --set trento-web.adminUser.password=adminpassword
```

@abravosuse We should add the usage of these 2 variable somewhere in the docs. The `pruneEventsOlderThan` and `pruneEventsCronjobSchedule`. I could help you elaborating the text of course
For example, putting `0` means all the events will be executed (by default every hour). This has the big disadvantage that we cannot debug what happened (or we miss a lot of information at least)