### PR TITLE
Enable rolling releases for script packages in OBS

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -186,7 +186,7 @@ jobs:
       - name: Prepare OBS package
         run: |
           PACKAGE_FOLDER=$FOLDER/${{ matrix.packages }}
-          osc checkout $OBS_PROJECT ${{ matrix.packages }} $DEST_FOLDER
+          osc checkout $OBS_PROJECT ${{ matrix.packages }} -o $DEST_FOLDER
           cp $PACKAGE_FOLDER/_service $DEST_FOLDER
           cp $PACKAGE_FOLDER/${{ matrix.packages }}.spec $DEST_FOLDER
           rm $DEST_FOLDER/*.tar.gz

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -148,16 +148,16 @@ jobs:
           osc ar
           osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
 
-  obs-commit-installer:
+  obs-commit-installer-and-plugin:
     needs: [test-helm-charts]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
       image: ghcr.io/trento-project/continuous-delivery:main
-      env:
-        PACKAGE_NAME: trento-server-installer
-        FOLDER: packaging/suse/trento-server-installer
       options: -u 0:0
+    strategy:
+      matrix:
+        packages: ["trento-server-installer", "trento-supportconfig-plugin"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -175,13 +175,12 @@ jobs:
           mkdir -p $HOME/.config/osc
           cp /home/osc/.config/osc/oscrc $HOME/.config/osc
           /scripts/init_osc_creds.sh
-      - name: Prepare .changes file
-        # The .changes file is updated only in release creation. This current task should be improved
-        # in order to add the current rolling release notes
-        if: github.event_name == 'release'
+      - name: Prepare .changes file and prepare OBS package
         run: |
-          CHANGES_FILE=$PACKAGE_NAME.changes
-          osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
+          CHANGES_FILE=${{ matrix.packages }}.changes
+          FOLDER=packaging/suse/${{ matrix.packages }}
+          osc checkout $OBS_PROJECT ${{ matrix.packages }} $CHANGES_FILE
+          osc service manualrun
           mv $CHANGES_FILE $FOLDER
           TAG=${{ steps.latest-tag.outputs.tag }}
           hack/gh_release_to_obs_changeset.py ${{ github.repository }} -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
@@ -194,52 +193,7 @@ jobs:
           sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
       - name: Commit on OBS
-        run: /scripts/upload.sh
-
-  obs-commit-plugin:
-    needs: [test-helm-charts]
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
-    container:
-      image: ghcr.io/trento-project/continuous-delivery:main
-      env:
-        PACKAGE_NAME: trento-supportconfig-plugin
-        FOLDER: packaging/suse/trento-supportconfig-plugin
-      options: -u 0:0
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: latest-tag
-        with:
-          semver_only: true
-          initial_version: 0.0.1
-      - name: Configure OSC
-        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-        # that is used to run osc commands
         run: |
-          mkdir -p $HOME/.config/osc
-          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
-          /scripts/init_osc_creds.sh
-      - name: Prepare .changes file
-        # The .changes file is updated only in release creation. This current task should be improved
-        # in order to add the current rolling release notes
-        if: github.event_name == 'release'
-        run: |
-          CHANGES_FILE=$PACKAGE_NAME.changes
-          osc checkout $OBS_PROJECT $PACKAGE_NAME $CHANGES_FILE
-          mv $CHANGES_FILE $FOLDER
-          TAG=${{ steps.latest-tag.outputs.tag }}
-          hack/gh_release_to_obs_changeset.py ${{ github.repository }} -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
-      - name: prepare _service file
-        run: |
-          git config --global --add safe.directory /__w/helm-charts/helm-charts
-          # Using get_version_from_git script as it creates a more meaningful version string (tag+sha) which is interesting
-          # only for rpm packages
-          VERSION=$(./hack/get_version_from_git.sh)
-          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
-      - name: Commit on OBS
-        run: /scripts/upload.sh
+          pushd $OSC_CHECKOUT_DIR
+          osc ar
+          osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -148,12 +148,15 @@ jobs:
           osc ar
           osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
 
-  obs-commit-installer-and-plugin:
+  obs-commit-scripts:
     needs: [test-helm-charts]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
       image: ghcr.io/trento-project/continuous-delivery:main
+      env:
+        DEST_FOLDER: "/tmp/osc_project"
+        FOLDER: packaging/suse
       options: -u 0:0
     strategy:
       matrix:
@@ -169,31 +172,34 @@ jobs:
           semver_only: true
           initial_version: 0.0.1
       - name: Configure OSC
-        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-        # that is used to run osc commands
         run: |
           mkdir -p $HOME/.config/osc
           cp /home/osc/.config/osc/oscrc $HOME/.config/osc
           /scripts/init_osc_creds.sh
-      - name: Prepare .changes file and prepare OBS package
-        run: |
-          CHANGES_FILE=${{ matrix.packages }}.changes
-          FOLDER=packaging/suse/${{ matrix.packages }}
-          osc checkout $OBS_PROJECT ${{ matrix.packages }} $CHANGES_FILE
-          osc service manualrun
-          mv $CHANGES_FILE $FOLDER
-          TAG=${{ steps.latest-tag.outputs.tag }}
-          hack/gh_release_to_obs_changeset.py ${{ github.repository }} -a shap-staff@suse.de -t $TAG -f $FOLDER/$CHANGES_FILE
-      - name: prepare _service file
+      - name: Prepare _service file with version details
         run: |
           git config --global --add safe.directory /__w/helm-charts/helm-charts
-          # Using get_version_from_git script as it creates a more meaningful version string (tag+sha) which is interesting
-          # only for rpm packages
           VERSION=$(./hack/get_version_from_git.sh)
-          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+          PACKAGE_FOLDER=$FOLDER/${{ matrix.packages }}
+          sed -i 's~%%REVISION%%~${{ github.sha }}~' $PACKAGE_FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $PACKAGE_FOLDER/_service
+      - name: Prepare OBS package
+        run: |
+          PACKAGE_FOLDER=$FOLDER/${{ matrix.packages }}
+          osc checkout $OBS_PROJECT ${{ matrix.packages }} $DEST_FOLDER
+          cp $PACKAGE_FOLDER/_service $DEST_FOLDER
+          cp $PACKAGE_FOLDER/${{ matrix.packages }}.spec $DEST_FOLDER
+          rm $DEST_FOLDER/*.tar.gz
+          pushd $DEST_FOLDER
+          osc service manualrun
+      - name: Prepare .changes file
+        if: github.event_name == 'release'
+        run: |
+          CHANGES_FILE=${{ matrix.packages }}.changes
+          TAG=${{ steps.latest-tag.outputs.tag }}
+          hack/gh_release_to_obs_changeset.py ${{ github.repository }} -a shap-staff@suse.de -t $TAG -f $DEST_FOLDER/$CHANGES_FILE
       - name: Commit on OBS
         run: |
-          pushd $OSC_CHECKOUT_DIR
+          pushd $DEST_FOLDER
           osc ar
           osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"

--- a/packaging/suse/trento-server-installer/_service
+++ b/packaging/suse/trento-server-installer/_service
@@ -1,15 +1,15 @@
 <services>
-    <service name="tar_scm" mode="disabled">
+    <service name="tar_scm" mode="manual">
         <param name="url">https://github.com/trento-project/helm-charts.git</param>
         <param name="scm">git</param>
         <param name="filename">trento-server-installer</param>
         <param name="revision">%%REVISION%%</param>
         <param name="versionformat">%%VERSION%%</param>
     </service>
-    <service name="set_version" mode="disabled">
+    <service name="set_version" mode="manual">
         <param name="file">trento-server-installer.spec</param>
     </service>
-    <service name="recompress" mode="disabled">
+    <service name="recompress" mode="manual">
         <param name="file">*.tar</param>
         <param name="compression">gz</param>
     </service>

--- a/packaging/suse/trento-supportconfig-plugin/_service
+++ b/packaging/suse/trento-supportconfig-plugin/_service
@@ -1,15 +1,15 @@
 <services>
-    <service name="tar_scm" mode="disabled">
+    <service name="tar_scm" mode="manual">
         <param name="url">https://github.com/trento-project/helm-charts.git</param>
         <param name="scm">git</param>
         <param name="filename">trento-supportconfig-plugin</param>
         <param name="revision">%%REVISION%%</param>
         <param name="versionformat">%%VERSION%%</param>
     </service>
-    <service name="set_version" mode="disabled">
+    <service name="set_version" mode="manual">
         <param name="file">trento-supportconfig-plugin.spec</param>
     </service>
-    <service name="recompress" mode="disabled">
+    <service name="recompress" mode="manual">
         <param name="file">*.tar</param>
         <param name="compression">gz</param>
     </service>


### PR DESCRIPTION
This PR changes the _service files for the scripts and takes care of updating the OBS packages in a rolling release form on each commit to main.