### PR TITLE
Add env var support for the supportconfig plugin/wrapper

### DIFF
--- a/scripts/trento-support.sh
+++ b/scripts/trento-support.sh
@@ -10,8 +10,10 @@ declare -A VALID_FACILITIES=(
     ["all"]="all"
 )
 
-RELEASE_NAME="trento-server"
-NAMESPACE="default"
+# These two variables can be set from the env as its the
+# supportconfig plugin wrapper doesn't allow for arguments
+RELEASE_NAME=${TRENTO_CHART_RELEASE_NAME:-"trento-server"}
+NAMESPACE=${TRENTO_K8S_NAMESPACE:-"default"}
 OUTPUT=/dev/stdout
 
 indent() { sed 's/^/  /'; }
@@ -125,8 +127,10 @@ usage() {
     Options:
         -o, --output        Output type. Options: stdout|file|file-tgz
         -c, --collect       Collection options: configuration|base|kubernetes|all
-        -r, --release-name  Release name to use for the chart installation. "trento-server" by default.
-        -n, --namespace     Kubernetes namespace used when installing the chart. "default" by default.
+        -r, --release-name  Release name to use for the chart installation. Default value: "trento-server".
+                            Can also be set with the TRENTO_CHART_RELEASE_NAME environment variable.
+        -n, --namespace     Kubernetes namespace used when installing the chart. Default value: "default".
+                            Can also be set with the TRENTO_K8S_NAMESPACE environment variable.
         -h, --help
 
     Example:


### PR DESCRIPTION
This PR allows the trento supportconfig plugin (a wrapper around trento-support.sh) to use env vars as a source for both the k8s namespace and the chart installation release name.

Tested manually:

w/o env vars:
```
#==[ Command ]======================================#
# /usr/local/bin/kubectl get nodes -o wide -n default
NAME         STATUS   ROLES                  AGE   VERSION        INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION             CONTAINER-RUNTIME
linux-5l8b   Ready    control-plane,master   23d   v1.27.6+k3s1   172.22.99.150   <none>        openSUSE Leap 15.2   5.3.18-lp152.106-default   containerd://1.7.6-k3s1.27
#==[ Command ]======================================#
# /usr/local/bin/kubectl get pods -n default
No resources found in default namespace.
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-server-wanda -c init -n default
Error from server (NotFound): deployments.apps "trento-server-wanda" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-server-wanda -n default
Error from server (NotFound): deployments.apps "trento-server-wanda" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-server-web -c init -n default
Error from server (NotFound): deployments.apps "trento-server-web" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-server-web -n default
Error from server (NotFound): deployments.apps "trento-server-web" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl describe deployments -n default
No resources found in default namespace.
... (output suppressed)
```

w env vars set:
```
# export TRENTO_K8S_NAMESPACE='trento-ns'
# export TRENTO_CHART_RELEASE_NAME='trento-srv'
# supportconfig -i ptrento
```
```
#==[ Command ]======================================#
# /usr/local/bin/kubectl get nodes -o wide -n trento-ns
NAME         STATUS   ROLES                  AGE   VERSION        INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION             CONTAINER-RUNTIME
linux-5l8b   Ready    control-plane,master   23d   v1.27.6+k3s1   172.22.99.150   <none>        openSUSE Leap 15.2   5.3.18-lp152.106-default   containerd://1.7.6-k3s1.27
#==[ Command ]======================================#
# /usr/local/bin/kubectl get pods -n trento-ns
No resources found in trento-ns namespace.
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-srv-wanda -c init -n trento-ns
Error from server (NotFound): namespaces "trento-ns" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-srv-wanda -n trento-ns
Error from server (NotFound): namespaces "trento-ns" not found
#==[ Command ]======================================#
# /usr/local/bin/kubectl logs deploy/trento-srv-web -c init -n trento-ns
Error from server (NotFound): namespaces "trento-ns" not found
#==[ Command ]======================================#
... (output suppressed)
```