### PR TITLE
Add option to disable charts

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.2.1-dev2
+version: 2.2.1-dev3
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1-dev1
+version: 2.2.1-dev2

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   ALERT_RECIPIENT: "{{ .Values.alerting.recipient }}"
   PROMETHEUS_URL: "http://{{ .Release.Name }}-{{ .Values.global.prometheus.name }}"
   AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
+  CHARTS_ENABLED: "{{ .Values.chartsEnabled }}"

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -25,6 +25,8 @@ adminUser:
   username: "admin"
   password: ""
 
+chartsEnabled: true
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Together with disabling prometheus usage, add the option to disable the charts.
We can achieve that adding the next flags to helm:
```
--set prometheus.enabled=false --set trento-web.chartsEnabled=false
```