### PR TITLE
Fix checks image tag

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.3.3-dev4
+version: 2.3.3-dev5
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -41,7 +41,7 @@ trento-wanda:
       registry: ghcr.io
       repository: trento-project/checks
       pullPolicy: IfNotPresent
-      tag: rolling
+      tag: 0.2.0
 
 postgresql:
   enabled: true


### PR DESCRIPTION
We need a fixed version in the values for the checks image otherwise we won't be able to bump it and having `rolling` won't trigger any redownload.