### PR TITLE
Make secret key base configurable

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.3.3-dev7
+version: 2.3.3-dev8
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1-dev3
+version: 1.3.1-dev4

--- a/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
@@ -73,12 +73,16 @@ Return Trento Wanda service port
 {{- end -}}
 
 {{- define "trento-wanda.secretKeyBase" -}}
-  {{ $secretName := (print (include "trento-wanda.fullname" .) "-secret") }}
-  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
-  {{- if $secret -}}
-    {{- index $secret "data" "SECRET_KEY_BASE" -}}
+  {{- if .Values.secretKeyBase -}}
+    {{- .Values.secretKeyBase | b64enc -}}
   {{- else -}}
-    {{- (randAlphaNum 64) | b64enc -}}
+    {{ $secretName := (print (include "trento-wanda.fullname" .) "-secret") }}
+    {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+    {{- if $secret -}}
+      {{- index $secret "data" "SECRET_KEY_BASE" -}}
+    {{- else -}}
+      {{- (randAlphaNum 64) | b64enc -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/trento-server/charts/trento-wanda/values.yaml
+++ b/charts/trento-server/charts/trento-wanda/values.yaml
@@ -22,6 +22,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.3.0
 
+secretKeyBase: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.3-dev4
+version: 2.3.3-dev5

--- a/charts/trento-server/charts/trento-web/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-web/templates/_helpers.tpl
@@ -93,12 +93,16 @@ Return Trento Web service port
 {{- end -}}
 
 {{- define "trento.web.secretKeyBase" -}}
-  {{ $secretName := (print (include "trento-web.fullname" .) "-secret") }}
-  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
-  {{- if $secret -}}
-    {{- index $secret "data" "SECRET_KEY_BASE" -}}
+  {{- if .Values.secretKeyBase -}}
+    {{- .Values.secretKeyBase | b64enc -}}
   {{- else -}}
-    {{- (randAlphaNum 64) | b64enc -}}
+    {{ $secretName := (print (include "trento-web.fullname" .) "-secret") }}
+    {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+    {{- if $secret -}}
+      {{- index $secret "data" "SECRET_KEY_BASE" -}}
+    {{- else -}}
+      {{- (randAlphaNum 64) | b64enc -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -73,6 +73,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.3.2
 
+secretKeyBase: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Make web and wanda secret key base configurable from the outside, so the value is not auto-generated.

This can be helpful in certain scenarios where auto-generated value can have issues (for example, you constantly install/uninstall the chart without deleting the postgresql pvc).

To use it simply add `--set trento-web.secretKeyBase=secret --set trento-wanda.secretKeyBase`.

Keep in mind, that everytime this value is given it must have the same value!

If you are doing a `helm update` in the other hand, you can omit the value in the 2nd time, as the key is stored as a secret in the 1st installation, and it can be fetched from there in the 2nd time.

@abravosuse I'm putting you here, as this have some impacts. First of, it opens some scenario where the user can things even worst (they use different keys in every helm usage), and in reality, this feature is just for strange scenarios (as commented above, you uninstall and install without wiping out the postgresql pvc for some reason).

We can decide to ditch this feature if we don't allow the previously commented scenario as supported (install/uninstall/install without cleaning pvc)