### PR TITLE
Import CA certificates

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.3.3-dev8
+version: 2.3.3-dev9
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.3-dev5
+version: 2.3.3-dev6

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -28,10 +28,15 @@ spec:
       serviceAccountName: {{ include "trento-web.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.saml.enabled }}
       volumes:
+      {{- if .Values.saml.enabled }}
       - name: saml-data
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.caStoreConfigmap }}
+      - name: {{ .Values.caStoreConfigmap }}
+        configMap:
+          name: {{ .Values.caStoreConfigmap }}
       {{- end }}
       initContainers:
         - name: create-trento-db
@@ -103,10 +108,15 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.saml.enabled }}
           volumeMounts:
+          {{- if .Values.saml.enabled }}
             - name: saml-data
               mountPath: {{ .Values.saml.spDir }}
+          {{- end }}
+          {{- if .Values.caStoreConfigmap }}
+            - name: {{ .Values.caStoreConfigmap }}
+              mountPath: /usr/share/pki/trust/anchors/
+              readOnly: true
           {{- end }}
           envFrom:
             - configMapRef:
@@ -117,6 +127,15 @@ spec:
                 name: {{ .Release.Name }}-auth-tokens-secret
           args:
             - start
+          {{- if .Values.caStoreConfigmap }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - update-ca-certificates
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -65,6 +65,7 @@ saml:
   signedEnvelopes: true
 
 chartsEnabled: true
+caStoreConfigmap: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
**Update**: Apparently, the initial certificates we created for our demo IDP, they were created wrong, and that's why we were required to upload them to the machine. This means, that the requirement of uploading custom CA certs shouldn't be that important (actually, It would become a small corner case), so we can postpone this by now

Add option to import CA certificates to the cluster.
When SSO options are used and the IPD is hosted using TLS, the client (trento web in this case) must have the CA certificate installed in the system. This in helm is not a default scenario in many cases.

In order to have the option to import the CA certificates, I have added this new variable `caStoreConfigmap` that we can use for this purpose.
The usage would be like:

1. Download the server CA (the whole chain) to your local machine as a `.pem` file. Put this certificate in a new folder
2. Create a config map so the content can be uploaded to helm. For that: `kubectl create configmap ca-pemstore --from-file=/folder_with_ca/`. The name `ca-pemstore` can be any other string
3. Run helm as usual adding this new variable: `helm ... --set trento-web.caStoreConfigmap=ca-pemstore`

With this, all the content in the `/folder_with_ca/` is imported in the pod and trento web can use them.


