### PR TITLE
Updated defaults for alerting settings

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,22 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-<<<<<<< HEAD
-#!BuildTag: trento/trento-server:2.5.0
-#!BuildTag: trento/trento-server:2.5.0-build%RELEASE%
-=======
 #!BuildTag: trento/trento-server:2.6.0-dev1
 #!BuildTag: trento/trento-server:2.6.0-dev1-build%RELEASE%
->>>>>>> cc6ed0c (Version bump)
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-<<<<<<< HEAD
-version: 2.5.0
-=======
 version: 2.6.0-dev1
->>>>>>> cc6ed0c (Version bump)
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
+<<<<<<< HEAD
 #!BuildTag: trento/trento-server:2.5.0
 #!BuildTag: trento/trento-server:2.5.0-build%RELEASE%
+=======
+#!BuildTag: trento/trento-server:2.6.0-dev1
+#!BuildTag: trento/trento-server:2.6.0-dev1-build%RELEASE%
+>>>>>>> cc6ed0c (Version bump)
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
+<<<<<<< HEAD
 version: 2.5.0
+=======
+version: 2.6.0-dev1
+>>>>>>> cc6ed0c (Version bump)
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,8 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-<<<<<<< HEAD
-version: 2.5.0
-=======
 version: 2.6.0-dev1
->>>>>>> cc6ed0c (Version bump)

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+<<<<<<< HEAD
 version: 2.5.0
+=======
+version: 2.6.0-dev1
+>>>>>>> cc6ed0c (Version bump)

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -5,12 +5,26 @@ metadata:
 data:
   DATABASE_URL: "ecto://{{ .Values.global.postgresql.postgresqlUsername }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Release.Name }}-{{ .Values.global.postgresql.name }}/trento"
   EVENTSTORE_URL: "ecto://{{ .Values.global.postgresql.postgresqlUsername }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Release.Name }}-{{ .Values.global.postgresql.name }}/trento_event_store"
-  ENABLE_ALERTING: "{{ .Values.alerting.enabled }}"
-  SMTP_SERVER: "{{ .Values.alerting.smtpServer }}"
-  SMTP_PORT: "{{ .Values.alerting.smtpPort }}"
-  SMTP_USER: "{{ .Values.alerting.smtpUser }}"
-  ALERT_SENDER: "{{ .Values.alerting.sender }}"
-  ALERT_RECIPIENT: "{{ .Values.alerting.recipient }}"
+  {{- with .Values.alerting }}
+  {{- if not (eq .enabled nil) }}
+  ENABLE_ALERTING: {{ .enabled }}
+  {{- end }}
+  {{- if not (eq .smtpServer nil) }}
+  SMTP_SERVER: {{ .smtpServer }}
+  {{- end }}
+  {{- if not (eq .smtpPort nil) }}
+  SMTP_PORT: {{ .smtpPort }}
+  {{- end }}
+  {{- if not (eq .smtpUser nil) }}
+  SMTP_USER: {{ .smtpUser }}
+  {{- end }}
+  {{- if not (eq .sender nil) }}
+  ALERT_SENDER: {{ .sender }}
+  {{- end }}
+  {{- if not (eq .recipient nil) }}
+  ALERT_RECIPIENT: {{ .recipient }}
+  {{- end }}
+  {{- end }}
   PROMETHEUS_URL: "http://{{ .Release.Name }}-{{ .Values.global.prometheus.name }}"
   AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
   CHARTS_ENABLED: "{{ .Values.chartsEnabled }}"

--- a/charts/trento-server/charts/trento-web/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/secret.yaml
@@ -5,7 +5,9 @@ metadata:
 type: Opaque
 data:
   SECRET_KEY_BASE: {{ include "trento.web.secretKeyBase" . | quote }}
+  {{- if not (eq .Values.alerting.smtpPassword nil) }}
   SMTP_PASSWORD: {{ .Values.alerting.smtpPassword | b64enc | quote }}
+  {{- end }}
   ADMIN_USER: {{ .Values.adminUser.username | b64enc | quote}}
   ADMIN_PASSWORD: {{- if .Values.adminUser.password }} {{ .Values.adminUser.password | b64enc | quote }}{{- else }} {{ include "trento.web.adminPassword" . | quote }}{{- end}}
   OIDC_CLIENT_SECRET: {{ .Values.oidc.clientSecret | b64enc | quote }}

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -13,13 +13,13 @@ global:
     name: prometheus-server
 
 alerting:
-  enabled: false
-  smtpServer: ""
-  smtpPort: ""
-  smtpUser: ""
-  smtpPassword: ""
-  sender: ""
-  recipient: ""
+  enabled: null
+  smtpServer: null
+  smtpPort: null
+  smtpUser: null
+  smtpPassword: null
+  sender: null
+  recipient: null
 
 adminUser:
   username: "admin"


### PR DESCRIPTION
Updated trento-web chart with new default alerting settings. The new values are all `null` which have the semantics of "not explicitly set", meaning that no OS environment variables for alerting would be set in the ConfigMap. 

This allows `trento-web` to be configured for alerting via WebUI by default. Only the default values and their implication for creating ConfigMap values are changed -- old installations that already modify values with `--set` would operate as expected. 

Implementation notice: Although the implementation seems a bit repetitive, I find it the most clear and concise. Extracting the common functionality into its own "function" (or rather "named template") leads to error-prone new-line/whitespace tracking that is not idiomatic nor easy to use. IMO, using `include` with template that is expected to return either a value or be skipped is unsolvable and should be handled with lower level if statements.