### PR TITLE
Setup rabbitmq tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /charts/**/*.tgz
+certs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ After that, refer to each individual chart documentation to find more informatio
 
 [cert-manager](https://cert-manager.io/) is a Kubernetes add-on that automates the management and issuance of TLS certificates. It can be optionally enabled in this Helm chart to provide SSL support for secure communication. While it simplifies certificate management and renewal, it introduces additional cluster-wide resources. For detailed setup instructions and considerations, refer to the [`hack/cert-manager/`](/hack/cert-manager/README.md) cookbook.
 
+### Optional: mTLS authentication with RabbitMQ
+
+mTLS authentication with RabbitMQ can be enabled through the `global.rabbitmq.tls` configuration section. This feature enhances security by ensuring mutual authentication between RabbitMQ and its clients. 
+When mTLS is enabled, the following secrets are expected to exist in the Kubernetes namespace:
+
+1. `rabbitmq-tls-server`
+    - `ca.crt`: Root CA certificate for the RabbitMQ server
+    - `tls.crt`: Server certificate for RabbitMQ
+    - `tls.key`: Private key for the RabbitMQ server certificate
+1. `rabbitmq-tls-client-web`
+    - `ca.crt`: Root CA certificate for web component
+    - `client.crt`: Client certificate for web component
+    - `client.key`: Private key for web client certificate
+1. `rabbitmq-tls-client-wanda`
+    - `ca.crt`: Root CA certificate for wanda component
+    - `client.crt`: Client certificate for wanda component
+    - `client.key`: Private key for wanda client certificate
+
 ## Support
 
 Please only report bugs via [GitHub issues](https://github.com/trento-project/trento/issues);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ After that, refer to each individual chart documentation to find more informatio
 
 ### Optional: mTLS authentication with RabbitMQ
 
-mTLS authentication with RabbitMQ can be enabled through the `global.rabbitmq.tls` configuration section. This feature enhances security by ensuring mutual authentication between RabbitMQ and its clients. 
+mTLS authentication with RabbitMQ can be enabled through the `global.rabbitmq.auth.tls` configuration section. This feature enhances security by ensuring mutual authentication between RabbitMQ and its clients. 
 When mTLS is enabled, the following secrets are expected to exist in the Kubernetes namespace:
 
 1. `rabbitmq-tls-server`

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:2.6.0-dev1
-#!BuildTag: trento/trento-server:2.6.0-dev1-build%RELEASE%
+#!BuildTag: trento/trento-server:2.6.0-dev2
+#!BuildTag: trento/trento-server:2.6.0-dev2-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.6.0-dev1
+version: 2.6.0-dev2
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
@@ -4,7 +4,11 @@ metadata:
   name: {{ include "trento-wanda.fullname" . }}-configmap
 data:
   DATABASE_URL: "ecto://{{ .Values.global.postgresql.postgresqlUsername }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Release.Name }}-{{ .Values.global.postgresql.name }}/trento_wanda"
-  AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
+  {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+  AMQP_URL: "amqps://{{ .Values.global.rabbitmq.auth.username }}:{{ .Values.global.rabbitmq.auth.password }}@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}?certfile=/var/rabbitmq/ssl/client.crt&keyfile=/var/rabbitmq/ssl/client.key&cacertfile=/var/rabbitmq/ssl/ca.crt&verify=verify_peer"
+  {{- else }}
+  AMQP_URL: "amqp://{{ .Values.global.rabbitmq.auth.username }}:{{ .Values.global.rabbitmq.auth.password }}@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
+  {{- end }}
   CORS_ENABLED: {{ .Values.cors.enabled | quote }}
   {{- if .Values.cors.enabled }}
   CORS_ORIGIN: {{ include "trentoWanda.cors_origin" . | quote }}

--- a/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
           volumeMounts:
             - name: checks
               mountPath: /usr/share/trento/checks
+          {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+            - name: rabbitmq-mtls-certs
+              mountPath: /var/rabbitmq/ssl
+              readOnly: true
+          {{- end }}
         - name: create-wanda-db
           image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           command:
@@ -102,9 +107,30 @@ spec:
             - name: checks
               mountPath: /usr/share/trento/checks
               readOnly: true
+          {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+            - name: rabbitmq-mtls-certs
+              mountPath: /var/rabbitmq/ssl
+              readOnly: true
+            - name: rabbitmq-mtls-certs-ca
+              mountPath: /usr/local/share/ca-certificates/ca.crt
+              subPath: ca.crt
+              readOnly: true
+          {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "update-ca-certificates"]
       volumes:
         - name: checks
           emptyDir: {}
+      {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+        - name: rabbitmq-mtls-certs
+          secret:
+            secretName: rabbitmq-tls-client-wanda
+        - name: rabbitmq-mtls-certs-ca
+          secret:
+            secretName: rabbitmq-tls-client-wanda
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -26,8 +26,12 @@ data:
   {{- end }}
   {{- end }}
   PROMETHEUS_URL: "http://{{ .Release.Name }}-{{ .Values.global.prometheus.name }}"
-  AMQP_URL: "amqp://trento:trento@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
   CHARTS_ENABLED: "{{ .Values.chartsEnabled }}"
+  {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+  AMQP_URL: "amqps://{{ .Values.global.rabbitmq.auth.username }}:{{ .Values.global.rabbitmq.auth.password }}@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}?certfile=/var/rabbitmq/ssl/client.crt&keyfile=/var/rabbitmq/ssl/client.key&cacertfile=/var/rabbitmq/ssl/ca.crt&verify=verify_peer"
+  {{- else }}
+  AMQP_URL: "amqp://{{ .Values.global.rabbitmq.auth.username }}:{{ .Values.global.rabbitmq.auth.password }}@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.servicePort }}"
+  {{- end }}
   TRENTO_WEB_ORIGIN: "{{ .Values.trentoWebOrigin }}"
   ENABLE_OIDC: "{{ .Values.oidc.enabled }}"
   OIDC_CLIENT_ID: "{{ .Values.oidc.clientId }}"

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -28,8 +28,8 @@ spec:
       serviceAccountName: {{ include "trento-web.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.saml.enabled }}
       volumes:
+      {{- if .Values.saml.enabled }}
       - name: saml-data
         emptyDir: {}
       {{- end }}
@@ -91,8 +91,8 @@ spec:
         - name: init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.saml.enabled }}
           volumeMounts:
+          {{- if .Values.saml.enabled }}
             - name: saml-data
               mountPath: {{ .Values.saml.spDir }}
           {{- end }}
@@ -113,8 +113,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.saml.enabled }}
           volumeMounts:
+          {{- if .Values.saml.enabled }}
             - name: saml-data
               mountPath: {{ .Values.saml.spDir }}
           {{- end }}

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
       - name: saml-data
         emptyDir: {}
       {{- end }}
+      {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+      - name: rabbitmq-mtls-certs
+        secret:
+          secretName: rabbitmq-tls-client-web
+      {{- end }}
       initContainers:
         - name: create-trento-db
           image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -91,6 +96,11 @@ spec:
             - name: saml-data
               mountPath: {{ .Values.saml.spDir }}
           {{- end }}
+          {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+            - name: rabbitmq-mtls-certs
+              mountPath: /var/rabbitmq/ssl
+              readOnly: true
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "trento-web.fullname" . }}-configmap
@@ -107,6 +117,11 @@ spec:
           volumeMounts:
             - name: saml-data
               mountPath: {{ .Values.saml.spDir }}
+          {{- end }}
+          {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+            - name: rabbitmq-mtls-certs
+              mountPath: /var/rabbitmq/ssl
+              readOnly: true
           {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/trento-server/templates/rabbitmq-configmap.yaml
+++ b/charts/trento-server/templates/rabbitmq-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-rabbitmq-configmap
+data:
+  extraConfiguration: |
+    {{- if .Values.global.rabbitmq.auth.tls.enabled }}
+    listeners.ssl.default = {{ .Values.global.rabbitmq.servicePort }}
+    listeners.tcp = none
+    ssl_options.cacertfile = /opt/bitnami/rabbitmq/certs/ca_certificate.pem
+    ssl_options.certfile = /opt/bitnami/rabbitmq/certs/server_certificate.pem
+    ssl_options.keyfile = /opt/bitnami/rabbitmq/certs/server_key.pem
+    ssl_options.verify = verify_peer
+    ssl_options.fail_if_no_peer_cert = true
+    {{- else }}
+    listeners.tcp.default = {{ .Values.global.rabbitmq.servicePort }}
+    {{- end }}
+
+    default_user = {{ .Values.global.rabbitmq.auth.username }}
+    default_pass = {{ .Values.global.rabbitmq.auth.password }}

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -17,6 +17,11 @@ global:
   rabbitmq:
     name: rabbitmq
     servicePort: 5672
+    auth:
+      username: "trento"
+      password: "trento"
+      tls:
+        enabled: false
 
 ### Sub Charts Specific Values ###
 trento-web:
@@ -65,8 +70,11 @@ rabbitmq:
   enabled: true
   persistence:
     enabled: true
-  auth:
-    username: trento
-    password: trento
   service:
     type: LoadBalancer
+  auth:
+    tls:
+      enabled: false
+      existingSecret: rabbitmq-tls-server
+      existingSecretFullChain: false
+  extraEnvVarsCM: trento-server-rabbitmq-configmap

--- a/hack/rabbitmq-tls/README.md
+++ b/hack/rabbitmq-tls/README.md
@@ -1,0 +1,12 @@
+# Generate TLS certificates for RabbitMQ
+
+Generates certificates for RabbitMQ TLS using the official generator tool. Certificates are meant to be used for development and QA.
+Please refere to the [official documentation](https://www.rabbitmq.com/docs/ssl#automated-certificate-generation-transcript).
+
+## Usage
+
+```sh
+docker build -f ./hack/rabbitmq-tls/generator.Dockerfile -t generator
+docker run --rm -it -v "$PWD":/output generator
+tree certs
+```

--- a/hack/rabbitmq-tls/README.md
+++ b/hack/rabbitmq-tls/README.md
@@ -1,7 +1,7 @@
 # Generate TLS certificates for RabbitMQ
 
 Generates certificates for RabbitMQ TLS using the official generator tool. Certificates are meant to be used for development and QA.
-Please refere to the [official documentation](https://www.rabbitmq.com/docs/ssl#automated-certificate-generation-transcript).
+Please refer to the [official documentation](https://www.rabbitmq.com/docs/ssl#automated-certificate-generation-transcript).
 
 ## Usage
 

--- a/hack/rabbitmq-tls/generator
+++ b/hack/rabbitmq-tls/generator
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+PROFILE_DIR=${1:-"./basic"}
+RELEASE_NAME=${2:-"trento-server"}
+
+# check if output directory exists
+# if it does, ask for confirmation to overwrite
+if [ -d "/output/certs" ]; then
+    read -p "Output directory /output/certs already exists. Do you want to overwrite it? (y/n): " confirm
+    if [[ "$confirm" != "y" ]]; then
+        echo "Exiting without overwriting."
+        exit 1
+    else
+        echo "Overwriting existing directory /output/certs."
+        rm -rf /output/certs
+    fi
+fi
+
+# Generate the CA and server certificates
+
+pushd "$PROFILE_DIR"
+
+make CN="$RELEASE_NAME"-rabbitmq PASSWORD=    
+make alias-leaf-artifacts CN="$RELEASE_NAME"-rabbitmq PASSWORD= 
+make CN=wanda CLIENT_ALT_NAME=wanda gen-client
+make CN=web CLIENT_ALT_NAME=web gen-client
+
+popd
+
+# Move the generated files to the output directory
+
+pushd "$PROFILE_DIR/result"
+
+mkdir -p /output/certs
+cp ca_certificate.pem ca_key.pem \
+    server_certificate.pem server_key.pem \
+    client_wanda_certificate.pem client_wanda_key.pem \
+    client_web_certificate.pem client_web_key.pem \
+    /output/certs
+
+popd

--- a/hack/rabbitmq-tls/generator.Dockerfile
+++ b/hack/rabbitmq-tls/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/tumbleweed
+FROM opensuse/tumbleweed:20250627
 
 RUN zypper --non-interactive install curl tar make python3 python3-pip hostname
 
@@ -15,4 +15,3 @@ RUN mkdir /output
 
 ENV RELEASE_NAME=trento-server
 CMD [ "sh", "-c",  "/app/generator /tls-gen/basic $RELEASE_NAME" ]
- 

--- a/hack/rabbitmq-tls/generator.Dockerfile
+++ b/hack/rabbitmq-tls/generator.Dockerfile
@@ -1,0 +1,18 @@
+FROM opensuse/tumbleweed
+
+RUN zypper --non-interactive install curl tar make python3 python3-pip hostname
+
+RUN curl -L https://github.com/rabbitmq/tls-gen/archive/efb3766277d99c6b8512f226351c7a62f492ef3f.tar.gz -o /tmp/tls-gen.tar.gz \
+    && tar -xzf /tmp/tls-gen.tar.gz -C / \
+    && mv /tls-gen-efb3766277d99c6b8512f226351c7a62f492ef3f /tls-gen \
+    && rm /tmp/tls-gen.tar.gz
+
+RUN mkdir /app 
+WORKDIR /app
+COPY generator /app/generator
+
+RUN mkdir /output
+
+ENV RELEASE_NAME=trento-server
+CMD [ "sh", "-c",  "/app/generator /tls-gen/basic $RELEASE_NAME" ]
+ 

--- a/scripts/create-certificates-secrets.sh
+++ b/scripts/create-certificates-secrets.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+#
+# Script: Upload PKI Certificates as Kubernetes Secrets
+#
+# Description:
+# This script creates Kubernetes secrets from existing PKI certificates.
+# It uploads CA certificates, server certificates, and client certificates
+# to a specified namespace as Kubernetes secrets for use with RabbitMQ TLS.
+#
+# Usage:
+#   ./create-certificates-secrets.sh [namespace] [certs_dir]
+#
+# Arguments:
+#   namespace    Optional. Target namespace for the secrets.
+#               If not specified, 'default' namespace is used.
+#   certs_dir   Optional. Directory containing the certificates.
+#               If not specified, current directory is used.
+#
+# Requirements:
+#   - kubectl with proper cluster access
+#   - Certificate files in the following structure:
+#     /path/to/certificates/
+#     ├── ca_certificate.pem
+#     ├── server_certificate.pem
+#     ├── server_key.pem
+#     ├── client_web_certificate.pem
+#     ├── client_web_key.pem
+#     ├── client_wanda_certificate.pem
+#     └── client_wanda_key.pem
+#
+# The following secrets will be created:
+#
+# 1. rabbitmq-tls-server
+#    - ca.crt    (from ca_certificate.pem)
+#    - tls.crt   (from server_certificate.pem)
+#    - tls.key   (from server_key.pem)
+#
+# 2. rabbitmq-tls-client-web
+#    - ca.crt     (from ca_certificate.pem)
+#    - client.crt (from client_web_certificate.pem)
+#    - client.key (from client_web_key.pem)
+#
+# 3. rabbitmq-tls-client-wanda
+#    - ca.crt     (from ca_certificate.pem)
+#    - client.crt (from client_wanda_certificate.pem)
+#    - client.key (from client_wanda_key.pem)
+#
+
+set -euo pipefail
+
+# Namespace for secrets (customize as needed)
+NAMESPACE=${1:-default}
+# Directory containing the generated certificates
+CERTS_DIR=${2:-"."}
+# Ensure the namespace exists
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+# Ensure the directory exists
+if [ ! -d "$CERTS_DIR" ]; then
+  echo "Directory $CERTS_DIR does not exist. Please provide a valid directory containing the certificates."
+  exit 1
+fi
+
+
+# Change to the directory containing the certificates
+pushd "$CERTS_DIR"
+
+# Create secret for RabbitMQ server's certificate and private key
+kubectl create secret generic rabbitmq-tls-server \
+  --from-file=ca.crt=ca_certificate.pem \
+  --from-file=tls.crt=server_certificate.pem \
+  --from-file=tls.key=server_key.pem \
+  --namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Create secret for web client certificate and key
+kubectl create secret generic rabbitmq-tls-client-web \
+  --from-file=ca.crt=ca_certificate.pem \
+  --from-file=client.crt=client_web_certificate.pem \
+  --from-file=client.key=client_web_key.pem \
+  --namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Create secret for wanda client certificate and key
+kubectl create secret generic rabbitmq-tls-client-wanda \
+  --from-file=ca.crt=ca_certificate.pem \
+  --from-file=client.crt=client_wanda_certificate.pem \
+  --from-file=client.key=client_wanda_key.pem \
+  --namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Kubernetes TLS secrets created in namespace: $NAMESPACE"
+
+# List the created secrets
+kubectl get secrets -n $NAMESPACE -o wide | grep rabbitmq-tls
+
+popd


### PR DESCRIPTION
Fixes https://github.com/trento-project/helm-charts/pull/132
Superseeds https://github.com/trento-project/helm-charts/pull/133

This is a rewrite of #132 that had to be reverted due to some problems.

* TLS is disabled by default
* Certificates are uploaded into secrets. See `README` for details
* A generator script for development purposes is provided in `./hack/rabbitmq-tls`

