### PR TITLE
[TRNT-3948] Use `bitnamilegacy` img repository for rabbitmq

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -6,7 +6,7 @@ name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
-version: 2.6.0-dev6
+version: 2.6.0-dev7
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -79,3 +79,5 @@ rabbitmq:
       existingSecret: rabbitmq-tls-server
       existingSecretFullChain: false
   extraEnvVarsCM: "{{ .Release.Name }}-rabbitmq-configmap"
+  image:
+    repository: bitnamilegacy/rabbitmq


### PR DESCRIPTION
# Description

Since https://github.com/trento-project/helm-charts/pull/144 is taking some time to get merged, this PR is just a simple workaround to keep the helm chart working in the meantime. 