### PR TITLE
[TRNT-3854] Improve notes

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:2.6.0-dev.15
-#!BuildTag: trento/trento-server:2.6.0-dev.15-build%RELEASE%
+#!BuildTag: trento/trento-server:2.6.0-dev.16
+#!BuildTag: trento/trento-server:2.6.0-dev.16-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 2.6.0-dev.15
+version: 2.6.0-dev.16
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-mcp-server/templates/NOTES.txt
+++ b/charts/trento-server/charts/trento-mcp-server/templates/NOTES.txt
@@ -34,7 +34,7 @@ To use the MCP server, add the following to your MCP client config:
             "type": "http",
             "url": "{{ $mcpUrl }}",
             "headers": {
-                "{{ .Values.mcpServer.headerName }}": "<your-trento-api-key>"
+                "{{ .Values.mcpServer.headerName }}": "<your-trento-pat>"
             }
         }
     }

--- a/charts/trento-server/charts/trento-mcp-server/templates/NOTES.txt
+++ b/charts/trento-server/charts/trento-mcp-server/templates/NOTES.txt
@@ -30,7 +30,7 @@ To use the MCP server, add the following to your MCP client config:
 
 {
     "servers": {
-        "trento": {
+        "mcp-server-trento": {
             "type": "http",
             "url": "{{ $mcpUrl }}",
             "headers": {
@@ -39,6 +39,16 @@ To use the MCP server, add the following to your MCP client config:
         }
     }
 }
+
+In MCPHost, you can use the following configuration:
+
+mcpServers:
+  mcp-server-trento:
+    type: remote
+    url: {{ $mcpUrl }}
+    headers:
+      - "Authorization: Bearer ${env://TRENTO_PAT}"
+
 {{- if .Values.mcpServer.args }}
 
 Note: Custom command-line arguments are configured. Ensure the header name matches your server configuration.

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0-dev.5
+version: 2.6.0-dev.6

--- a/charts/trento-server/charts/trento-web/templates/NOTES.txt
+++ b/charts/trento-server/charts/trento-web/templates/NOTES.txt
@@ -5,16 +5,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host | default "localhost" }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.webService.type }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "trento-web.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.webService.type }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "trento-web.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "trento-web.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.webService.type }}
+{{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "trento-web.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"


### PR DESCRIPTION
This PR adds the MCPHost configuration as part of the helm (sub)chart notes. The output would be sth like:

```console
To use the MCP server, add the following to your MCP client config:

{
    "servers": {
        "mcp-server-trento": {
            "type": "http",
            "url": "https://mytrento.example.com/mcp-server-trento/mcp",
            "headers": {
                "Authorization": "<your-trento-api-key>"
            }
        }
    }
}

In MCPHost, you can use the following configuration:

mcpServers:
  mcp-server-trento:
    type: remote
    url: https://mytrento.example.com/mcp-server-trento/mcp
    headers:
      - "Authorization: Bearer ${env://TRENTO_PAT}"

Service Access:
- Internal: http://trento-server-mcp-server.deleteme.svc.cluster.local:5000/mcp
- External: https://mytrento.example.com/mcp-server-trento/mcp
```

Also fixing a nil pointer when disabling ingress in trento-web.

Note that, currently, we are not recommending passing ` --render-subchart-notes `, nor are we adding the relevant pieces of notes in the main NOTES.txt. That means this information is not shown by default.


<details><summary>Details</summary>

```console
NOTES:
Trento Server installed!
                _  _ _  _                   _  _ _  _
               | |_| |_| |                 | |_| |_| |
               \  .      /                 \ .    .  /
                \    ,  /                   \    .  /
                 | .   |_   _   _   _   _   _| ,   |
                 |    .| |_| |_| |_| |_| |_| |  .  |
                 | ,   | .    .     .      . |    .|
                 |   . |  .     . .   .  ,   |.    |
     ___----_____| .   |.   ,  _______   .   |   , |---~_____
_---~            |     |  .   /+++++++\    . | .   |         ~---_
                 |.    | .    |+++++++| .    |   . |              ~-_
              __ |   . |   ,  |+++++++|.  . _|__   |                 ~-_
     ____--`~    '--~~__ .    |++++ __|----~    ~`---,              ___^~-__
-~--~                   ~---__|,--~'                  ~~----_____-~'   `~----~

See https://www.trento-project.io/docs/user-guide/trento-install-server.html#sec-trento-k8s-deployment for extra information about using an ingress that is not traefik.
URL: http://localhost
The Prometheus server can be accessed via port 80 on the following DNS name from within your cluster:
trento-server-prometheus-server.deleteme.svc.cluster.local


Get the Prometheus server URL by running these commands in the same shell:
  export POD_NAME=$(kubectl get pods --namespace deleteme -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace deleteme port-forward $POD_NAME 9090


#################################################################################
######   WARNING: Pod Security Policy has been moved to a global property.  #####
######            use .Values.podSecurityPolicy.enabled with pod-based      #####
######            annotations                                               #####
######            (e.g. .Values.nodeExporter.podSecurityPolicy.annotations) #####
#################################################################################



For more information on running Prometheus, visit:
https://prometheus.io/

1. Get the application URL by running these commands:
  http://localhost/


################################################################################
#                        BEGIN TRENTO MCP SERVER                               #
################################################################################

Trento MCP Server Configuration:

  TRENTO_MCP_OAS_PATH: "http://trento-server-web.deleteme.svc.cluster.local:4000/api/all/openapi,http://trento-server-wanda.deleteme.svc.cluster.local:4000/api/all/openapi"
  TRENTO_MCP_TRENTO_URL: ""
  TRENTO_MCP_AUTODISCOVERY_PATHS: "/api/all/openapi,/wanda/api/all/openapi"
  TRENTO_MCP_PORT: "5000"
  TRENTO_MCP_ENABLE_HEALTH_CHECK: "true"
  TRENTO_MCP_HEALTH_PORT: "8080"
  TRENTO_MCP_HEALTH_API_PATH: "/api/healthz"
  TRENTO_MCP_TRANSPORT: "streamable"
  TRENTO_MCP_HEADER_NAME: "Authorization"
  TRENTO_MCP_TAG_FILTER: "MCP"
  TRENTO_MCP_VERBOSITY: "info"
  TRENTO_MCP_INSECURE_SKIP_TLS_VERIFY: "false"

To use the MCP server, add the following to your MCP client config:

{
    "servers": {
        "mcp-server-trento": {
            "type": "http",
            "url": "https:///mcp-server-trento/mcp",
            "headers": {
                "Authorization": "<your-trento-api-key>"
            }
        }
    }
}

In MCPHost, you can use the following configuration:

mcpServers:
  mcp-server-trento:
    type: remote
    url: https:///mcp-server-trento/mcp
    headers:
      - "Authorization: Bearer ${env://TRENTO_PAT}"

Service Access:
- Internal: http://trento-server-mcp-server.deleteme.svc.cluster.local:5000/mcp
- External: https:///mcp-server-trento/mcp

################################################################################
#                             END TRENTO MCP SERVER                            #
################################################################################

** Please be patient while the chart is being deployed **

PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:

    trento-server-postgresql.deleteme.svc.cluster.local - Read/Write connection

To get the password for "postgres" run:

    export POSTGRES_PASSWORD=$(kubectl get secret --namespace deleteme trento-server-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)

To connect to your database run the following command:

    kubectl run trento-server-postgresql-client --rm --tty -i --restart='Never' --namespace deleteme --image registry.suse.com/suse/postgres:14 --env="PGPASSWORD=$POSTGRES_PASSWORD" --command -- psql --host trento-server-postgresql -U postgres -d postgres -p 5432



To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace deleteme svc/trento-server-postgresql 5432:5432 &
    PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
1. Get the application URL by running these commands:
  http:///wanda
```
</details> 
