### PR TITLE
Allow serving Trento from a subpath

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: trento/trento-server:3.0.0
-#!BuildTag: trento/trento-server:3.0.0-build%RELEASE%
+#!BuildTag: trento/trento-server:3.0.1-dev1
+#!BuildTag: trento/trento-server:3.0.1-dev1-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.0.0
+version: 3.0.1-dev1
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1-dev1

--- a/charts/trento-server/charts/trento-web/templates/ingress.yaml
+++ b/charts/trento-server/charts/trento-web/templates/ingress.yaml
@@ -22,8 +22,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
     {{- if eq $.Values.ingress.className "traefik" }}
-    # This middleware makes sure that the /api/session/token/introspect endpoint is not accessible
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ include "trento-web.fullname" $ }}-no-introspection@kubernetescrd
+    # Middlewares: block introspect, strip /trento prefix, and set X-Forwarded-Prefix header
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ include "trento-web.fullname" $ }}-no-introspection@kubernetescrd,{{ $.Release.Namespace }}-{{ include "trento-web.fullname" $ }}-strip-trento@kubernetescrd,{{ $.Release.Namespace }}-{{ include "trento-web.fullname" $ }}-set-prefix-header@kubernetescrd
     {{- end }}
   {{- end }}
 spec:

--- a/charts/trento-server/charts/trento-web/templates/middleware.yaml
+++ b/charts/trento-server/charts/trento-web/templates/middleware.yaml
@@ -3,6 +3,9 @@ Copyright 2025 SUSE LLC
 SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if and .Values.ingress.enabled (eq .Values.ingress.className "traefik") }}
+{{- $firstHost := index .Values.ingress.hosts 0 -}}
+{{- $firstPath := index $firstHost.paths 0 -}}
+{{- $basePath := $firstPath.path -}}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -10,7 +13,32 @@ metadata:
   labels:
   {{- include "trento-web.labels" . | nindent 4 }}
 spec:
+  # Block requests to the introspection endpoint
   replacePathRegex:
-    regex: "^/api/session/token/introspect$"
+    regex: "^{{ $basePath }}/api/session/token/introspect$"
     replacement: "/not-found"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "trento-web.fullname" . }}-strip-trento
+  labels:
+  {{- include "trento-web.labels" . | nindent 4 }}
+spec:
+  # Strip base path prefix from all requests so Phoenix receives clean paths
+  replacePathRegex:
+    regex: "^{{ $basePath }}(.*)$"
+    replacement: "$1"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "trento-web.fullname" . }}-set-prefix-header
+  labels:
+  {{- include "trento-web.labels" . | nindent 4 }}
+spec:
+  # Add X-Forwarded-Prefix header so Phoenix knows about the base path prefix
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Prefix: {{ $basePath }}
 {{- end }}


### PR DESCRIPTION
# Description

Following up on https://github.com/trento-project/web/pull/3948, this PR introduces the changes required for letting Trento know the subpath we are using in the Ingress rule. For example, to serve `foo.example.com/trento`, we'd just need to do:

```yaml
ingress:
  hosts:
    - host: "foo.example.com"
      paths:
        - path: /trento
        # ...
```
