### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -20,17 +20,17 @@ jobs:
   test-helm-charts:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.4.0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
       - name: Lint
         run: ct lint --config=ct.yaml --lint-conf=helmlintconf.yaml --helm-lint-extra-args="--set prometheus.server.auth.type=none"
 
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [test-helm-charts]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: compress
         run: |
           set -x
           find ./charts/ -maxdepth 1 -mindepth 1 -exec sh -c 'tar -zcf $(basename {}).tgz -C charts/ ./$(basename {})/' \;
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: charts
           path: |
@@ -54,10 +54,10 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: charts
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "rolling"
@@ -72,7 +72,7 @@ jobs:
     if: github.event.release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -80,13 +80,13 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.7.2
       - name: Add dependency chart repos
         run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Version }}"
@@ -106,10 +106,10 @@ jobs:
         charts: ["trento-server"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1
         id: latest-tag
         with:
           semver_only: true

--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Auto-merge
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: ridedott/merge-me-action@v2
+        uses: ridedott/merge-me-action@d6325f17fb7e2d3728f83f6872ef7858dddd0dc1 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRESET: DEPENDABOT_MINOR


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 14
    Already pinned (SHA)         : 0
    Pinned in this run           : 14
    Resolved from cache          : 7
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A

