### PR TITLE
Prometheus url prefix

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -7,7 +7,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.0.2-dev4
+version: 3.0.2-dev5
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
   ALERT_RECIPIENT: "{{ .recipient }}"
   {{- end }}
   {{- end }}
-  PROMETHEUS_URL: "http://{{ .Release.Name }}-{{ .Values.global.prometheus.name }}"
+  PROMETHEUS_URL: "http://{{ .Release.Name }}-{{ .Values.global.prometheus.name }}{{ .Values.global.prometheus.pathPrefix }}"
   {{- if .Values.global.rabbitmq.tls.mtls.enabled }}
   AMQP_URL: "amqps://{{ .Values.global.rabbitmq.auth.username }}:{{ .Values.global.rabbitmq.auth.password }}@{{ .Release.Name }}-{{ .Values.global.rabbitmq.name }}:{{ .Values.global.rabbitmq.ports.amqpTls }}?cacertfile=/etc/certs/rabbitmq/ca.crt&certfile=/etc/certs/rabbitmq/tls.crt&keyfile=/etc/certs/rabbitmq/tls.key"
   {{- else }}

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -19,6 +19,7 @@ global:
     postgresqlPassword: "postgres"
   prometheus:
     name: prometheus-server
+    pathPrefix: /prometheus
   rabbitmq:
     name: rabbitmq
     servicePort: 5672


### PR DESCRIPTION
The prefix is needed when Trento web queries Prometheus metrics