### PR TITLE
Switched GH releases to produce OCI artifacts

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -38,7 +38,8 @@ jobs:
     name: Chart rolling release on GitHub
     needs:
       - test-helm-charts
-    if: github.event_name == 'push'
+    # TODO: Remove `pull_request` trigger!!!!
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     uses: ./.github/workflows/publish-oci.yaml
     with:
       branch: main

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -38,8 +38,7 @@ jobs:
     name: Chart rolling release on GitHub
     needs:
       - test-helm-charts
-    # TODO: Remove `pull_request` trigger!!!!
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/publish-oci.yaml
     with:
       branch: main

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -41,7 +41,7 @@ jobs:
     if: github.event_name == 'push'
     uses: ./.github/workflows/publish-oci.yaml
     with:
-      branch: main
+      branch: ${{ github.ref_name }}
       prerelease: true
     secrets:
       gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}
@@ -54,7 +54,7 @@ jobs:
     if: ${{ github.event.release && github.ref != 'refs/tags/rolling' }}
     uses: ./.github/workflows/publish-oci.yaml
     with:
-      branch: main
+      branch: ${{ github.ref_name }}
       prerelease: false
     secrets:
       gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -52,7 +52,7 @@ jobs:
     name: Chart release on GitHub
     needs:
       - test-helm-charts
-    if: github.event.release
+    if: ${{ github.event.release && github.ref != 'refs/tags/rolling' }}
     uses: ./.github/workflows/publish-oci.yaml
     with:
       branch: main

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -34,62 +34,31 @@ jobs:
       - name: Lint
         run: ct lint --config=ct.yaml --lint-conf=helmlintconf.yaml --helm-lint-extra-args="--set prometheus.server.auth.type=none"
 
-  create-artifact:
-    runs-on: ubuntu-24.04
-    needs: [test-helm-charts]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: compress
-        run: |
-          set -x
-          find ./charts/ -maxdepth 1 -mindepth 1 -exec sh -c 'tar -zcf $(basename {}).tgz -C charts/ ./$(basename {})/' \;
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: charts
-          path: |
-            *.tgz
+  gh-release-rolling:
+    name: Chart rolling release on GitHub
+    needs:
+      - test-helm-charts
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/publish-oci.yaml
+    with:
+      branch: main
+      prerelease: true
+    secrets:
+      gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}
+      ssh_key: ${{ secrets.TRENTOBOT_SSH_KEY }}
 
-  release-rolling:
-    needs: [test-helm-charts, create-artifact]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: charts
-      - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "rolling"
-          prerelease: true
-          title: "Cutting Edge"
-          files: |
-            trento-server.tgz
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [test-helm-charts]
+  gh-release:
+    name: Chart release on GitHub
+    needs:
+      - test-helm-charts
     if: github.event.release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.7.2
-      - name: Add dependency chart repos
-        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NAME_TEMPLATE: "{{ .Version }}"
+    uses: ./.github/workflows/publish-oci.yaml
+    with:
+      branch: main
+      prerelease: false
+    secrets:
+      gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}
+      ssh_key: ${{ secrets.TRENTOBOT_SSH_KEY }}
 
   obs-commit-charts:
     needs: [test-helm-charts]

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -14,7 +14,7 @@ on:
 env:
   OBS_USER: ${{ secrets.OBS_USER }}
   OBS_PASS: ${{ secrets.OBS_PASS }}
-  OBS_PROJECT: ${{ secrets.OBS_PROJECT}}
+  OBS_PROJECT: ${{ vars.OBS_PROJECT}}
 
 jobs:
   test-helm-charts:

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -46,6 +46,7 @@ jobs:
           oci_registry: ghcr.io/trento-project/helm-charts
           oci_username: trentobot
           oci_password: ${{ secrets.gh_token }}
+          github_token: ${{ secrets.gh_token }}
           # We can't control the name of the tag, so skipping release
           # in this action.
           skip_gh_release: true

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Delete rolling tag so it can be recreated
         if: inputs.prerelease
         run: |
-          gh release delete latest --cleanup-tag
+          gh release delete rolling --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -69,7 +69,7 @@ jobs:
           generate_release_notes: true
           make_latest: false
           files: |
-            ${{ runner.tool_cache }}/cra/linux-amd64/package/{${{ steps.chart-releaser.outputs.released_charts }}}/*
+            ${{ runner.tool_cache }}/cra/linux-amd64/package/charts/trento-server/*
 
       - name: Release version check
         if: ${{ ! inputs.prerelease }}
@@ -86,4 +86,4 @@ jobs:
           token: ${{ secrets.gh_token }}
           tag_name: ${{ steps.chart-releaser.outputs.chart_version }}
           files: |
-            ${{ runner.tool_cache }}/cra/linux-amd64/package/{${{ steps.chart-releaser.outputs.released_charts }}}/*
+            ${{ runner.tool_cache }}/cra/linux-amd64/package/charts/trento-server/*

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -50,7 +50,6 @@ jobs:
           # We can't control the name of the tag, so skipping release
           # in this action.
           skip_gh_release: true
-          install_dir: ${{ env.RUNNER_TEMP }}/trento
 
       - name: Delete rolling tag so it can be recreated
         if: inputs.prerelease
@@ -70,7 +69,7 @@ jobs:
           generate_release_notes: true
           make_latest: false
           files: |
-            ${{ env.RUNNER_TEMP }}/trento/packages/trento-server/*
+            ${{ env.RUNNER_TOOL_CACHE }}/cra/linux-amd64/packages/trento-server/*
 
       - name: Release version check
         if: ${{ ! inputs.prerelease }}
@@ -87,4 +86,4 @@ jobs:
           token: ${{ secrets.gh_token }}
           tag_name: ${{ steps.chart-releaser.outputs.chart_version }}
           files: |
-            ${{ env.RUNNER_TEMP }}/trento/packages/trento-server/*
+            ${{ env.RUNNER_TEMP }}/cra/linux-amd64/packages/trento-server/*

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -1,0 +1,89 @@
+---
+name: Publish OCI chart
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
+        default: main
+        description: The branch to build and publish.
+      prerelease:
+        type: boolean
+        default: false
+        description: >-
+          Whether the release is a pre-release. It's expected the
+          pre-release tag to be the same over time, eg. it's moving
+          target.
+
+    secrets:
+      gh_token:
+        description: GitHub Personal Access Token to interact with GH API.
+        required: true
+      ssh_key:
+        description: >-
+          SSH key to be used for repository access. The key needs
+          write permissions to the repository.
+        required: true
+
+jobs:
+  build-and-push:
+    name: Build chart and push to OCI registry
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need the full history because of `helm-oci-charts-releaser`
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+          ssh-key: ${{ secrets.ssh_key }}
+
+      - name: Package chart and upload to GHCR OCI registry
+        id: chart-releaser
+        uses: bitdeps/helm-oci-charts-releaser@caedceea2a5ab997c7e5469a999811dbb3d5b070 # v0.1.5
+        with:
+          oci_registry: ghcr.io/trento-project/helm-charts
+          oci_username: trentobot
+          oci_password: ${{ secrets.gh_token }}
+          # We can't control the name of the tag, so skipping release
+          # in this action.
+          skip_gh_release: true
+          install_dir: ${{ env.RUNNER_TEMP }}/trento
+
+      - name: Delete rolling tag so it can be recreated
+        if: inputs.prerelease
+        run: |
+          gh release delete latest --cleanup-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+      - name: Create pre-releaese and upload artifact
+        if: inputs.prerelease
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          token: "${{ secrets.gh_token }}"
+          name: "Cutting Edge"
+          tag_name: rolling
+          prerelease: true
+          generate_release_notes: true
+          make_latest: false
+          files: |
+            ${{ env.RUNNER_TEMP }}/trento/packages/trento-server/*
+
+      - name: Release version check
+        if: ${{ ! inputs.prerelease }}
+        run: |
+          if [ $(cat VERSION) != ${{ steps.chart-releaser.outputs.chart_version }} ]; then
+            echo "Version mismatch, can't proceed with the release"
+            exit 1
+          fi
+
+      - name: Upload artifact to already created release
+        if: ${{ ! inputs.prerelease }}
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          token: ${{ secrets.gh_token }}
+          tag_name: ${{ steps.chart-releaser.outputs.chart_version }}
+          files: |
+            ${{ env.RUNNER_TEMP }}/trento/packages/trento-server/*

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -69,7 +69,7 @@ jobs:
           generate_release_notes: true
           make_latest: false
           files: |
-            ${{ env.RUNNER_TOOL_CACHE }}/cra/linux-amd64/packages/trento-server/*
+            ${{ runner.tool_cache }}/cra/linux-amd64/package/{${{ steps.chart-releaser.outputs.released_charts }}}/*
 
       - name: Release version check
         if: ${{ ! inputs.prerelease }}
@@ -86,4 +86,4 @@ jobs:
           token: ${{ secrets.gh_token }}
           tag_name: ${{ steps.chart-releaser.outputs.chart_version }}
           files: |
-            ${{ env.RUNNER_TEMP }}/cra/linux-amd64/packages/trento-server/*
+            ${{ runner.tool_cache }}/cra/linux-amd64/package/{${{ steps.chart-releaser.outputs.released_charts }}}/*


### PR DESCRIPTION
Extracted the release process concerning GitHub into it's own workflow. This workflow will build the helm charts and upload them to GHCR _OCI registry_, as opposed to the legacy `index.yaml` one. Additionally, it would create a GH release and upload the built Helm chart as asset.
Apart from modernizing the GH release, this step is a prerequisite to the further work of unifying the release process. The old GH action used to create chart releases (`chart-releaser`) did not allow for re-using GH releases already created. This is a requirement for our common workflows, because they create the release as part of the `git-release` step. 

The switch to OCI registry has implications for how to download the chart. You should use `helm pull` (as opposed to `helm repo add`) to get the helm chart. But apart from that, I've tried to preserve everything else the same as before.

Additionally, `action-automatic-releases` is replaced with `action-gh-relase` because the first one is no longer maintained.