### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 root = true
 
 [*]

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        name: Check license headers
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
       - name: Lint

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Continuous Integration
 concurrency: ci-${{ github.ref }}
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 /charts/**/*.tgz

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-helm-charts
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.md"
+    - "**/.helmignore"
+    - "**/Chart.lock"
+    - "**/NOTES.txt"
+    - "**/_helmignore"
+    - "**/_service"
+    - ".github/CODEOWNERS"
+    - ".github/dependabot.yml"
+    - ".github_changelog_generator"
+    - "LICENSE"
+    - "NOTICE"
+    - "charts/trento-server/charts/postgresql"
+    - "charts/trento-server/charts/rabbitmq"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,55 @@
+trento-helm-charts
+
+Copyright SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This product may include a number of subcomponents with separate copyright notices and license terms.
+
+---
+
+charts/trento-server/charts/postgresql
+<https://github.com/bitnami/charts/blob/31a3beff085d30c227bfce42b015446fc723dc3b/LICENSE>
+
+Copyright (c) 2015-2021 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+charts/trento-server/charts/rabbitmq
+<https://github.com/bitnami/charts/blob/93b0f1a9c8027aa8ecfe548053257656bff76339/LICENSE.md>
+
+Copyright (c) 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -8,7 +8,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.0.2-dev7
+version: 3.0.2-dev8
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 #!BuildTag: trento/trento-server:3.0.1
 #!BuildTag: trento/trento-server:3.0.1-build%RELEASE%

--- a/charts/trento-server/charts/trento-mcp-server/Chart.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/Chart.yaml
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: trento-mcp-server
 description: Trento MCP Server chart

--- a/charts/trento-server/charts/trento-mcp-server/Chart.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2

--- a/charts/trento-server/charts/trento-mcp-server/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-mcp-server/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{/*

--- a/charts/trento-server/charts/trento-mcp-server/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/configmap.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/trento-server/charts/trento-mcp-server/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/trento-server/charts/trento-mcp-server/templates/ingress.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "trento-mcp-server.fullname" . -}}

--- a/charts/trento-server/charts/trento-mcp-server/templates/middleware.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/middleware.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 {{ if and .Values.ingress.enabled (eq .Values.ingress.className "traefik") }}
 apiVersion: traefik.io/v1alpha1

--- a/charts/trento-server/charts/trento-mcp-server/templates/networkpolicy.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy

--- a/charts/trento-server/charts/trento-mcp-server/templates/service.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/service.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 apiVersion: v1
 kind: Service

--- a/charts/trento-server/charts/trento-mcp-server/templates/serviceaccount.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1

--- a/charts/trento-server/charts/trento-mcp-server/values.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/trento-server/charts/trento-mcp-server/values.yaml
+++ b/charts/trento-server/charts/trento-mcp-server/values.yaml
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
-
 ## @section Common parameters
 ##
 ## @param image.repository Image repository

--- a/charts/trento-server/charts/trento-wanda/Chart.yaml
+++ b/charts/trento-server/charts/trento-wanda/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: trento-wanda
 description: Trento Wanda chart

--- a/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-wanda/templates/_helpers.tpl
@@ -1,3 +1,8 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/trento-server/charts/trento-wanda/templates/hpa.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/hpa.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/trento-server/charts/trento-wanda/templates/ingress.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/ingress.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "trento-wanda.fullname" . -}}
 {{- $svcPort := include "trentoWanda.port" . -}}

--- a/charts/trento-server/charts/trento-wanda/templates/middleware.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/middleware.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 {{ if and .Values.ingress.enabled (eq .Values.ingress.className "traefik") }}
 {{- $fullName := include "trento-wanda.fullname" . -}}
 apiVersion: traefik.io/v1alpha1

--- a/charts/trento-server/charts/trento-wanda/templates/rabbitmq-certificate.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/rabbitmq-certificate.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if and  .Values.global.rabbitmq.tls.mtls.enabled .Values.global.rabbitmq.tls.mtls.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/trento-server/charts/trento-wanda/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/secret.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/trento-server/charts/trento-wanda/templates/service.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/service.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/trento-server/charts/trento-wanda/templates/serviceaccount.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/serviceaccount.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/trento-server/charts/trento-wanda/templates/tests/test-connection.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/tests/test-connection.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/trento-server/charts/trento-wanda/values.yaml
+++ b/charts/trento-server/charts/trento-wanda/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Default values for wanda.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: trento-web
 description: Trento Web Chart

--- a/charts/trento-server/charts/trento-web/templates/_helpers.tpl
+++ b/charts/trento-server/charts/trento-web/templates/_helpers.tpl
@@ -1,3 +1,8 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -124,5 +129,3 @@ Return Trento Web service port
     {{- .Values.trentoWebOrigin -}}
 {{- end -}}
 {{- end -}}
-
-

--- a/charts/trento-server/charts/trento-web/templates/auth-tokens-secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/auth-tokens-secret.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/trento-server/charts/trento-web/templates/configmap.yaml
+++ b/charts/trento-server/charts/trento-web/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/trento-server/charts/trento-web/templates/hpa.yaml
+++ b/charts/trento-server/charts/trento-web/templates/hpa.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/trento-server/charts/trento-web/templates/ingress.yaml
+++ b/charts/trento-server/charts/trento-web/templates/ingress.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "trento-web.fullname" . -}}
 {{- $svcPort := include "trentoWeb.port" . -}}

--- a/charts/trento-server/charts/trento-web/templates/middleware.yaml
+++ b/charts/trento-server/charts/trento-web/templates/middleware.yaml
@@ -1,6 +1,6 @@
 {{- /*
-Copyright 2025 SUSE LLC
-SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if and .Values.ingress.enabled (eq .Values.ingress.className "traefik") }}
 apiVersion: traefik.io/v1alpha1

--- a/charts/trento-server/charts/trento-web/templates/rabbitmq-certificate.yaml
+++ b/charts/trento-server/charts/trento-web/templates/rabbitmq-certificate.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if and  .Values.global.rabbitmq.tls.mtls.enabled .Values.global.rabbitmq.tls.mtls.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/trento-server/charts/trento-web/templates/secret.yaml
+++ b/charts/trento-server/charts/trento-web/templates/secret.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/trento-server/charts/trento-web/templates/service.yaml
+++ b/charts/trento-server/charts/trento-web/templates/service.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/trento-server/charts/trento-web/templates/serviceaccount.yaml
+++ b/charts/trento-server/charts/trento-web/templates/serviceaccount.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/trento-server/charts/trento-web/templates/tests/test-web-connection.yaml
+++ b/charts/trento-server/charts/trento-web/templates/tests/test-web-connection.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Default values for trento-web.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/trento-server/templates/cert-manager-resources.yaml
+++ b/charts/trento-server/templates/cert-manager-resources.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if and  .Values.global.rabbitmq.tls.mtls.enabled .Values.global.rabbitmq.tls.mtls.certManager.enabled }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/trento-server/templates/prometheus-auth-configmap.yaml
+++ b/charts/trento-server/templates/prometheus-auth-configmap.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.prometheus.enabled -}}
 {{- if not (or (eq .Values.prometheus.server.auth.type "none") (eq .Values.prometheus.server.auth.type "basic")) }}
 {{- fail "Prometheus authentication must be explicitly set to 'none' or 'basic' via .Values.prometheus.server.auth.type" }}

--- a/charts/trento-server/templates/prometheus-configmap.yaml
+++ b/charts/trento-server/templates/prometheus-configmap.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/trento-server/templates/prometheus-migration-hook.yaml
+++ b/charts/trento-server/templates/prometheus-migration-hook.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.prometheus.enabled }}
 {{- /*
   Migrates the prometheus-server Deployment from the v15.x label schema to v25.x.

--- a/charts/trento-server/templates/prometheus-web-config-secret.yaml
+++ b/charts/trento-server/templates/prometheus-web-config-secret.yaml
@@ -1,3 +1,7 @@
+{{- /*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*/}}
 {{- if .Values.prometheus.enabled -}}
 {{- if eq .Values.prometheus.server.auth.type "basic" -}}
 apiVersion: v1

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ### Global Values ###
 global:
   clusterDomain: cluster.local

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # https://github.com/helm/chart-testing
 chart-dirs:
   - charts

--- a/hack/cert-manager/certificate.tpl.yaml
+++ b/hack/cert-manager/certificate.tpl.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/hack/cert-manager/cluster-issuer.tpl.yaml
+++ b/hack/cert-manager/cluster-issuer.tpl.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/hack/cert-manager/override-values.tpl.yaml
+++ b/hack/cert-manager/override-values.tpl.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 trento-web:
   ingress:
     hosts:

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 TAG=$( git tag | grep -E "[0-9]\.[0-9]\.[0-9]" | sort -rn | head -n1 )
 
 if [ -n "${TAG}" ]; then

--- a/hack/gh_release_to_obs_changeset.py
+++ b/hack/gh_release_to_obs_changeset.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 import argparse
 import json
 import os

--- a/helmlintconf.yaml
+++ b/helmlintconf.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 rules:
   braces:

--- a/packaging/suse/trento-server/Makefile
+++ b/packaging/suse/trento-server/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 NAME = trento-server
 
 YQ := $(shell command -v yq 2> /dev/null)

--- a/packaging/suse/trento-server/values-overwrite.yaml
+++ b/packaging/suse/trento-server/values-overwrite.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 trento-web:
   image:
     repository: registry.suse.com/trento/trento-web

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 set -e
 
 readonly ARGS=("$@")


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Finally, a NOTICE file is added, referecing the derivate works we include in the repo.

Related # TRNT-4358

## How was this tested?

License linter.