### PR TITLE
[TRNT-4409] Upgrade and extract helm version to var

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
       - "main"
   pull_request:
 
+env:
+  HELM_VERSION: v4.2.0
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -43,7 +46,7 @@ jobs:
           fetch-depth: 0
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.4.0
+          version: ${{ env.HELM_VERSION }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -29,6 +29,9 @@ on:
           write permissions to the repository.
         required: true
 
+env:
+  HELM_VERSION: v4.2.0
+
 jobs:
   build-and-push:
     name: Build chart and push to OCI registry
@@ -36,7 +39,7 @@ jobs:
     steps:
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.20.2
+          version: ${{ env.HELM_VERSION }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
# Description

This pull request just extracts the helm version we use into an env var. Besides, it is bumped up from `3.4.0` to `4.2.0`.

Since further PRs also use this pattern, this PR simply updates existing workflows.

Relate # TRNT-4409
