### PR TITLE
Add mcp server ingress

### DIFF
--- a/hack/cert-manager/override-values.tpl.yaml
+++ b/hack/cert-manager/override-values.tpl.yaml
@@ -24,3 +24,15 @@ trento-wanda:
       - secretName: trento-tls
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-production
+
+trento-mcp-server:
+  ingress:
+    hosts:
+      - host: ${TRENTO_WEB_ORIGIN}
+        paths:
+        - path: /mcp
+          pathType: ImplementationSpecific
+    tls:
+      - secretName: trento-tls
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-production


### PR DESCRIPTION
This PR extracts a change from https://github.com/trento-project/helm-charts/pull/195, so that we can merge it earlier and enable the MCP server on the demo environment.

Related TRNT-4408