### PR TITLE
Fix wrong checks image

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -8,7 +8,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.2.0-dev2
+version: 3.2.0-dev3
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -58,7 +58,7 @@ trento-wanda:
     repository: ghcr.io/trento-project/trento-wanda
   checks:
     image:
-      repository: ghcr.io/trento-project/trento-checks
+      repository: ghcr.io/trento-project/checks
 
 trento-mcp-server:
   nameOverride: mcp-server


### PR DESCRIPTION
### Description

This PR changes the checks image to `checks` in the OSS version, see https://github.com/trento-project/checks/pkgs/container/checks/952788326?tag=1.3.1. However, official builds will be replaced to the corresponding registry.suse.com image independently, see https://src.opensuse.org/SAP-trento/trento-server-helm/src/branch/main/values.yaml#L61

Related #TRNT-4408

### How was this tested?

See https://github.com/trento-project/helm-charts/pull/195#issuecomment-4751237155

### Documentation changes

No

### Additional information

N/A