### PR TITLE
Add liveness and readiness probes in Web and Wanda

### DIFF
--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -8,7 +8,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.2.0-dev2
+version: 3.2.0-dev4
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -8,7 +8,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.2.0-dev4
+version: 3.2.0-dev3
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/deployment.yaml
@@ -88,14 +88,19 @@ spec:
               containerPort: {{ template "trentoWanda.port" . }}
               protocol: TCP
           args: ['start']
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/charts/trento-server/charts/trento-web/templates/deployment.yaml
@@ -137,14 +137,19 @@ spec:
             - name: http
               containerPort: {{ template "trentoWeb.port" . }}
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /api/ping
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /api/ping
-          #     port: http
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
### Description

This PR changes adds the liveness and readiness probes to Trento Web and Wanda. This way, pods relying on unavailable dependencies won't be marked as ready to accept traffic.

Related #TRNT-4408

### How was this tested?

See https://github.com/trento-project/helm-charts/pull/195#issuecomment-4751237155

### Documentation changes

No

### Additional information

N/A