### PR TITLE
Fix issues with pgautoupgrade

### DIFF
--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -190,7 +190,7 @@ jobs:
         if: matrix.source != env.SOURCE_INSTALL_ONLY
         run: bash .github/scripts/helm-upgrade-helper.sh compare-container-versions
 
-      - name: Upgrade to current dev chart
+      - name: Install or upgrade to current dev chart
         run: |
           ACTION="${{ matrix.source == env.SOURCE_INSTALL_ONLY && 'install' || 'upgrade' }}"
           echo "Running helm ${ACTION} for source: ${{ matrix.source }}"

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -21,6 +21,7 @@ env:
   SOURCE_SUSE_RELEASE: suse-release
   SOURCE_OSS_RELEASE: oss-release
   SOURCE_OSS_MAIN: oss-main
+  SOURCE_INSTALL_ONLY: install-only
 
 jobs:
   upgrade-test:
@@ -59,6 +60,8 @@ jobs:
             source: oss-release
           - name: "OSS rolling → current"
             source: oss-main
+          - name: "Install current"
+            source: install-only
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,6 +77,7 @@ jobs:
 
       - name: Resolve chart version
         id: version
+        if: matrix.source != env.SOURCE_INSTALL_ONLY
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -136,6 +140,7 @@ jobs:
           echo "${{ github.token }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 
       - name: Install chart
+        if: matrix.source != env.SOURCE_INSTALL_ONLY
         run: |
           if [ "${{ matrix.source }}" = "${SOURCE_SUSE_RELEASE}" ]; then
             CHART_REF="oci://${SUSE_REGISTRY}"
@@ -156,6 +161,7 @@ jobs:
             ${HELM_COMMON_FLAGS}
 
       - name: Wait for RabbitMQ to be ready
+        if: matrix.source != env.SOURCE_INSTALL_ONLY
         run: |
           echo "Waiting for RabbitMQ to be ready..."
           kubectl wait --for=condition=ready pod \
@@ -164,7 +170,7 @@ jobs:
             --timeout=60s
 
       - name: Check pod status after install
-        if: always()
+        if: always() && matrix.source != env.SOURCE_INSTALL_ONLY
         run: bash .github/scripts/helm-upgrade-helper.sh post-install-diagnostics
 
       - name: Build dependencies for current dev chart
@@ -181,14 +187,19 @@ jobs:
           helm dependency build charts/trento-server
 
       - name: Compare container versions
+        if: matrix.source != env.SOURCE_INSTALL_ONLY
         run: bash .github/scripts/helm-upgrade-helper.sh compare-container-versions
 
       - name: Upgrade to current dev chart
         run: |
-          helm upgrade -i trento-server charts/trento-server --wait \
+          ACTION="${{ matrix.source == env.SOURCE_INSTALL_ONLY && 'install' || 'upgrade' }}"
+          echo "Running helm ${ACTION} for source: ${{ matrix.source }}"
+
+          helm ${ACTION} trento-server charts/trento-server --wait \
             --timeout 3m \
             --render-subchart-notes \
             --debug \
+            --create-namespace \
             ${HELM_COMMON_FLAGS} \
             --set trento-web.image.tag=rolling \
             --set trento-wanda.image.tag=rolling \

--- a/charts/trento-server/Chart.yaml
+++ b/charts/trento-server/Chart.yaml
@@ -8,7 +8,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 3.2.0-dev4
+version: 3.2.0-dev5
 
 dependencies:
   - name: trento-web

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -78,21 +78,32 @@ postgresql:
   primary:
     extraInitContainers:
       # Runs pg_upgrade in-place before PostgreSQL starts when the major version changes.
-      # PGAUTO_ONESHOT exits immediately with no-op when no upgrade is needed, so this is safe on every restart.
       # Image tag uses global.postgresql.image.tag with "-debian" appended automatically.
       # https://github.com/bitnami/charts/issues/14926#issuecomment-3192189184
       - name: upgrade-postgres
-        image: "pgautoupgrade/pgautoupgrade:{{ .Values.global.postgresql.image.tag }}-debian"
+        image: "pgautoupgrade/pgautoupgrade:{{ .Values.global.postgresql.image.tag }}-alpine"
         securityContext:
           runAsUser: 0
         volumeMounts:
           - name: data
             mountPath: "{{ .Values.persistence.mountPath }}"
+        command:
+          - /bin/bash
+          - -c
+          - |
+            # Only run pgautoupgrade if database already exists (upgrade scenario)
+            if [ -f "$PGDATA/PG_VERSION" ]; then
+              echo "Existing database detected, running pgautoupgrade..."
+              exec /usr/local/bin/docker-entrypoint.sh postgres
+            else
+              echo "Fresh install detected (no PG_VERSION), skipping pgautoupgrade"
+              exit 0
+            fi
         env:
           - name: PGAUTO_ONESHOT
             value: "yes"
           - name: POSTGRES_DB
-            value: "{{ if .Values.global.postgresql.postgresqlDatabase }}{{ .Values.global.postgresql.postgresqlDatabase }}{{ else if .Values.postgresqlDatabase }}{{ .Values.postgresqlDatabase }}{{ else }}postgres{{ end }}"
+            value: "{{ .Values.postgresqlDatabase }}"
           - name: PGDATA
             value: "{{ .Values.postgresqlDataDir }}"
 


### PR DESCRIPTION
### Description

I noticed #199 introduced a bug we didn't catch: when it is the very first time installing the chart (= PGDATA folder is empty), the `pgautoupgrade` command returns an error.

Also changing from debian to alpine as it fixes another error (mismatch in the collation provider, the string sorting library, usually provided by glibc).

Related #TRNT-4392
Related #TRNT-4408

### How was this tested?

I've added a new CI case in the matrix to test what we actually missed before: a fresh install test case. Instead of upgrading, the test case will just install the content of the PR. This way, we will catch failures like this one before they hit the main branch.

### Documentation changes

No

### Additional information

Sorry for the bug 😅 