### PR TITLE
Auto bump version in CVE workflow

### DIFF
--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -996,6 +996,38 @@ stage_and_commit() {
   }
 }
 
+# Bump the chart version in Chart.yaml using semver.
+# Args: $1 (string) - path to Chart.yaml file
+# Returns: 0 on success, 1 on failure
+# Outputs: New version string
+bump_chart_version() {
+  local chart_file="$1"
+
+  local current_version
+  current_version=$(yq eval '.version' "$chart_file")
+
+  if [ -z "$current_version" ] || [ "$current_version" = "null" ]; then
+    log_error "Could not read chart version from $chart_file"
+    return 1
+  fi
+
+  log_info "Current chart version: $current_version"
+
+  local new_version
+  new_version=$(semver bump prerel "$current_version")
+
+  if [ -z "$new_version" ]; then
+    log_error "Failed to bump chart version"
+    return 1
+  fi
+
+  log_info "Bumping chart version: $current_version → $new_version"
+
+  yq eval ".version = \"$new_version\"" -i "$chart_file"
+
+  echo "$new_version"
+}
+
 # Run the manage-pr step: commit the chart changes and open a GitHub pull request.
 # Args: $1 (string) - path to image-analysis JSON produced by analyze-sarif
 #       $2 (string) - path to upgrade-plan JSON produced by find-upgrade
@@ -1070,6 +1102,21 @@ manage_pr() {
     output_json=$(build_pr_result_json "" "" "" "no_changes")
     output_json "$output_file" "$output_json" || exit 1
     exit 0
+  fi
+
+  # Bump chart version
+  local chart_yaml="charts/trento-server/Chart.yaml"
+  if [ -f "$chart_yaml" ]; then
+    log_info "Bumping chart version in $chart_yaml"
+    if bump_chart_version "$chart_yaml"; then
+      # Add Chart.yaml to the list of updated files
+      updated_files=$(printf '%s\n%s' "$updated_files" "$chart_yaml")
+      log_success "Chart version bumped successfully"
+    else
+      log_warning "Failed to bump chart version - continuing without version bump"
+    fi
+  else
+    log_warning "Chart.yaml not found at $chart_yaml - skipping version bump"
   fi
 
   local cve_count commit_msg

--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -1014,7 +1014,10 @@ bump_chart_version() {
   log_info "Current chart version: $current_version"
 
   local new_version
-  new_version=$(semver bump prerel "$current_version")
+  if ! new_version=$(semver bump prerel "$current_version"); then
+    log_error "Failed to bump chart version"
+    return 1
+  fi
 
   if [ -z "$new_version" ]; then
     log_error "Failed to bump chart version"
@@ -1023,8 +1026,10 @@ bump_chart_version() {
 
   log_info "Bumping chart version: $current_version → $new_version"
 
-  yq eval ".version = \"$new_version\"" -i "$chart_file"
-
+  if ! yq eval --arg new_version "$new_version" '.version = $new_version' -i "$chart_file"; then
+    log_error "Failed to write bumped chart version to $chart_file"
+    return 1
+  fi
   echo "$new_version"
 }
 

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -300,6 +300,96 @@ EOF
 # manage-pr step Tests
 # ============================================================================
 
+@test "bump_chart_version: increments prerelease version" {
+  [ "$SEMVER_AVAILABLE" -eq 0 ] && skip "semver-tool not available"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  cat > "$tmpdir/Chart.yaml" << 'EOF'
+apiVersion: v2
+name: test-chart
+version: 3.2.0-dev6
+EOF
+
+  local new_version
+  new_version=$(bump_chart_version "$tmpdir/Chart.yaml")
+
+  [ "$new_version" = "3.2.0-dev7" ]
+
+  # Verify Chart.yaml was updated
+  local updated_version
+  updated_version=$(yq eval '.version' "$tmpdir/Chart.yaml")
+  [ "$updated_version" = "3.2.0-dev7" ]
+
+  rm -rf "$tmpdir"
+}
+
+@test "bump_chart_version: handles missing version field" {
+  [ "$SEMVER_AVAILABLE" -eq 0 ] && skip "semver-tool not available"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  cat > "$tmpdir/Chart.yaml" << 'EOF'
+apiVersion: v2
+name: test-chart
+EOF
+
+  run bump_chart_version "$tmpdir/Chart.yaml"
+
+  # Should fail when version is missing
+  [ "$status" -eq 1 ]
+
+  rm -rf "$tmpdir"
+}
+
+@test "bump_chart_version: handles different prerelease formats" {
+  [ "$SEMVER_AVAILABLE" -eq 0 ] && skip "semver-tool not available"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  cat > "$tmpdir/Chart.yaml" << 'EOF'
+apiVersion: v2
+name: test-chart
+version: 1.0.0-alpha.1
+EOF
+
+  local new_version
+  new_version=$(bump_chart_version "$tmpdir/Chart.yaml")
+
+  [ "$new_version" = "1.0.0-alpha.2" ]
+
+  rm -rf "$tmpdir"
+}
+
+@test "bump_chart_version: handles version without prerelease suffix" {
+  [ "$SEMVER_AVAILABLE" -eq 0 ] && skip "semver-tool not available"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  cat > "$tmpdir/Chart.yaml" << 'EOF'
+apiVersion: v2
+name: test-chart
+version: 1.0.0
+EOF
+
+  local new_version
+  new_version=$(bump_chart_version "$tmpdir/Chart.yaml")
+
+  # semver bump prerel on a version without prerelease adds -1
+  [ "$new_version" = "1.0.0-1" ]
+
+  # Verify Chart.yaml was updated
+  local updated_version
+  updated_version=$(yq eval '.version' "$tmpdir/Chart.yaml")
+  [ "$updated_version" = "1.0.0-1" ]
+
+  rm -rf "$tmpdir"
+}
+
 @test "generate_branch_name: creates valid branch name format" {
   local image_name="alertmanager"
   local target_tag="v0.26.0"


### PR DESCRIPTION
### Description

In #198 we created a workflow to update our dependencies to reduce CVEs, however, freshly created PR fails because they are not bumping up the Chart version. This PR is to autoupdate it.

Related #TRNT-4409

### How was this tested?

Unit BATS tests.

### Documentation changes

No


### Additional information

N/A