### PR TITLE
Filter out SHA OCI versions from CVE remediation

### DIFF
--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -182,8 +182,8 @@ find_compatible_upgrade() {
   local target_tag=""
 
   for tag in "${tag_array[@]}"; do
-    # Skip commit SHAs / digests: hex-only strings (7+ hex chars, no dots/separators)
-    if [[ "$tag" =~ ^[A-Fa-f0-9]+$ ]] && [[ ${#tag} -ge 7 ]]; then
+    # Filter hex strings (7+ chars) containing at least one hex letter.
+    if [[ "$tag" =~ ^[A-Fa-f0-9]{7,}$ ]] && [[ "$tag" =~ [A-Fa-f] ]]; then
       continue
     fi
 

--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -182,6 +182,11 @@ find_compatible_upgrade() {
   local target_tag=""
 
   for tag in "${tag_array[@]}"; do
+    # Skip commit SHAs: hex-only strings (7+ hex chars, no dots/separators)
+    if [[ "$tag" =~ ^[a-f0-9]+$ ]] && [[ ${#tag} -ge 7 ]]; then
+      continue
+    fi
+
     parse_output=$(parse_version "$tag" 2>/dev/null) || continue
 
     local tag_version="${parse_output%|*}"

--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -182,8 +182,8 @@ find_compatible_upgrade() {
   local target_tag=""
 
   for tag in "${tag_array[@]}"; do
-    # Skip commit SHAs: hex-only strings (7+ hex chars, no dots/separators)
-    if [[ "$tag" =~ ^[a-f0-9]+$ ]] && [[ ${#tag} -ge 7 ]]; then
+    # Skip commit SHAs / digests: hex-only strings (7+ hex chars, no dots/separators)
+    if [[ "$tag" =~ ^[A-Fa-f0-9]+$ ]] && [[ ${#tag} -ge 7 ]]; then
       continue
     fi
 

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -209,10 +209,10 @@ setup() {
   [ "$result" = "3.2.0" ]
 }
 
-@test "find_compatible_upgrade: skips Git commit SHA-256 (64 chars)" {
+@test "find_compatible_upgrade: skips SHA-256 digest (64 chars)" {
   # Current: 3.1.2
-  # Available: 64-char SHA-256, 3.2.0, 3.1.3
-  # Should return: 3.2.0 (highest valid, not the SHA-256)
+  # Available: 64-char SHA-256 digest, 3.2.0, 3.1.3
+  # Should return: 3.2.0 (highest valid, not the digest)
   local tags=("abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab" "3.2.0" "3.1.3")
   local result
   result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -198,6 +198,72 @@ setup() {
   [ "$result" = "2.0.0" ]
 }
 
+@test "find_compatible_upgrade: skips Git commit SHA-1 (40 chars)" {
+  # Current: 3.1.2
+  # Available: 7012366806370b50d3a915116d31ed373a1e8e70 (SHA-1), 3.2.0, 3.1.3
+  # Should return: 3.2.0 (highest valid, not the SHA)
+  local tags=("7012366806370b50d3a915116d31ed373a1e8e70" "3.2.0" "3.1.3")
+  local result
+  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+
+  [ "$result" = "3.2.0" ]
+}
+
+@test "find_compatible_upgrade: skips Git commit SHA-256 (64 chars)" {
+  # Current: 3.1.2
+  # Available: 64-char SHA-256, 3.2.0, 3.1.3
+  # Should return: 3.2.0 (highest valid, not the SHA-256)
+  local tags=("abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab" "3.2.0" "3.1.3")
+  local result
+  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+
+  [ "$result" = "3.2.0" ]
+}
+
+@test "find_compatible_upgrade: skips short Git SHAs (7-12 chars)" {
+  # Current: 3.1.2
+  # Available: short SHAs, 3.2.0
+  # Should return: 3.2.0 (short SHAs filtered out)
+  local tags=("abcdef7" "1234567890ab" "3.2.0" "deadbeef")
+  local result
+  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+
+  [ "$result" = "3.2.0" ]
+}
+
+@test "find_compatible_upgrade: skips all SHA tags when no valid versions" {
+  # Current: 3.1.2
+  # Available: only SHAs (various lengths)
+  # Should return: empty (no valid upgrades)
+  local tags=("abc1234" "7012366806370b50d3a915116d31ed373a1e8e70" "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+  local result
+  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+
+  [ -z "$result" ]
+}
+
+@test "find_compatible_upgrade: distinguishes SHA from version starting with digits" {
+  # Current: 3.1.2
+  # Available: 40-char SHA-1 starting with digit, valid version 3.2.0
+  # Should return: 3.2.0 (SHA should be filtered out)
+  local tags=("7012366806370b50d3a915116d31ed373a1e8e70" "3.2.0")
+  local result
+  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+
+  [ "$result" = "3.2.0" ]
+}
+
+@test "find_compatible_upgrade: allows hex-looking versions with dots" {
+  # Current: 1.0.0
+  # Available: 2.0.0abc (has dot, not a SHA), deadbeef (no dot, is SHA)
+  # Should return: empty (2.0.0abc isn't valid semver, deadbeef is filtered)
+  local tags=("deadbeef" "2.0.0abc")
+  local result
+  result=$(find_compatible_upgrade "1.0.0" "${tags[@]}")
+
+  [ -z "$result" ]
+}
+
 # ============================================================================
 # verify-image step Tests
 # ============================================================================

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -198,70 +198,43 @@ setup() {
   [ "$result" = "2.0.0" ]
 }
 
-@test "find_compatible_upgrade: skips Git commit SHA-1 (40 chars)" {
+@test "find_compatible_upgrade: skips Git SHAs of all lengths" {
   # Current: 3.1.2
-  # Available: 7012366806370b50d3a915116d31ed373a1e8e70 (SHA-1), 3.2.0, 3.1.3
-  # Should return: 3.2.0 (highest valid, not the SHA)
-  local tags=("7012366806370b50d3a915116d31ed373a1e8e70" "3.2.0" "3.1.3")
+  # Available: SHAs (7-char, 40-char SHA-1, 64-char SHA-256), valid versions
+  # Should return: 3.2.0 (all SHAs filtered, selects highest valid)
+  local tags=(
+    "abcdef7"  # 7-char short SHA
+    "7012366806370b50d3a915116d31ed373a1e8e70"  # 40-char SHA-1
+    "abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"  # 64-char SHA-256
+    "3.2.0"
+    "3.1.3"
+  )
   local result
   result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
 
   [ "$result" = "3.2.0" ]
 }
 
-@test "find_compatible_upgrade: skips SHA-256 digest (64 chars)" {
+@test "find_compatible_upgrade: returns empty when only SHAs available" {
   # Current: 3.1.2
-  # Available: 64-char SHA-256 digest, 3.2.0, 3.1.3
-  # Should return: 3.2.0 (highest valid, not the digest)
-  local tags=("abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab" "3.2.0" "3.1.3")
-  local result
-  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
-
-  [ "$result" = "3.2.0" ]
-}
-
-@test "find_compatible_upgrade: skips short Git SHAs (7-12 chars)" {
-  # Current: 3.1.2
-  # Available: short SHAs, 3.2.0
-  # Should return: 3.2.0 (short SHAs filtered out)
-  local tags=("abcdef7" "1234567890ab" "3.2.0" "deadbeef")
-  local result
-  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
-
-  [ "$result" = "3.2.0" ]
-}
-
-@test "find_compatible_upgrade: skips all SHA tags when no valid versions" {
-  # Current: 3.1.2
-  # Available: only SHAs (various lengths)
-  # Should return: empty (no valid upgrades)
-  local tags=("abc1234" "7012366806370b50d3a915116d31ed373a1e8e70" "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+  # Available: only SHAs (no valid versions)
+  # Should return: empty
+  local tags=("abc1234" "7012366806370b50d3a915116d31ed373a1e8e70")
   local result
   result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
 
   [ -z "$result" ]
 }
 
-@test "find_compatible_upgrade: distinguishes SHA from version starting with digits" {
-  # Current: 3.1.2
-  # Available: 40-char SHA-1 starting with digit, valid version 3.2.0
-  # Should return: 3.2.0 (SHA should be filtered out)
-  local tags=("7012366806370b50d3a915116d31ed373a1e8e70" "3.2.0")
+@test "find_compatible_upgrade: allows numeric-only tags" {
+  # Current: 20240101
+  # Available: numeric date tags (no letters), SHA (has letters)
+  # Should return: 20240707 (numeric tags allowed, SHAs filtered)
+  local tags=("20240707" "abc1234" "20240101" "1234567")
   local result
-  result=$(find_compatible_upgrade "3.1.2" "${tags[@]}")
+  result=$(find_compatible_upgrade "20240101" "${tags[@]}")
 
-  [ "$result" = "3.2.0" ]
-}
-
-@test "find_compatible_upgrade: allows hex-looking versions with dots" {
-  # Current: 1.0.0
-  # Available: 2.0.0abc (has dot, not a SHA), deadbeef (no dot, is SHA)
-  # Should return: empty (2.0.0abc isn't valid semver, deadbeef is filtered)
-  local tags=("deadbeef" "2.0.0abc")
-  local result
-  result=$(find_compatible_upgrade "1.0.0" "${tags[@]}")
-
-  [ -z "$result" ]
+  [ "$result" = "20240707" ]
 }
 
 # ============================================================================


### PR DESCRIPTION
### Description

This PR fixes an issue with the CVE remediation updater GHA: if a SHA is listed as a version, it might include it. This PR is to filter those SHA out, so that the version can be properly chosen.

Related #TRNT-4408

### How was this tested?

CI

### Documentation changes

No

### Additional information

This should prevent PRs like https://github.com/trento-project/helm-charts/pull/236 from being created.