### PR TITLE
Filter out "-env" suffixed tags from CVE remediation

### DIFF
--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -187,6 +187,11 @@ find_compatible_upgrade() {
       continue
     fi
 
+    # Skip internal testing tags with -env suffix (e.g., "720-env")
+    if [[ "$tag" =~ -env$ ]]; then
+      continue
+    fi
+
     parse_output=$(parse_version "$tag" 2>/dev/null) || continue
 
     local tag_version="${parse_output%|*}"

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -237,6 +237,17 @@ setup() {
   [ "$result" = "20240707" ]
 }
 
+@test "find_compatible_upgrade: skips internal -env tags" {
+  # Current: 2.0.0
+  # Available: internal -env tags, valid versions
+  # Should return: 2.1.0 (skips 720-env, 718-env)
+  local tags=("720-env" "2.1.0" "718-env" "2.0.0")
+  local result
+  result=$(find_compatible_upgrade "2.0.0" "${tags[@]}")
+
+  [ "$result" = "2.1.0" ]
+}
+
 # ============================================================================
 # verify-image step Tests
 # ============================================================================

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -248,6 +248,17 @@ setup() {
   [ "$result" = "2.1.0" ]
 }
 
+@test "find_compatible_upgrade: returns empty when only -env tags are newer" {
+  # Current: 2.0.0
+  # Available: 720-env, 718-env (newer but -env), 2.0.0 (equal, not an upgrade)
+  # Should return: empty (-env tags must never be selected as upgrade target)
+  local tags=("720-env" "718-env" "2.0.0")
+  local result
+  result=$(find_compatible_upgrade "2.0.0" "${tags[@]}")
+
+  [ -z "$result" ]
+}
+
 # ============================================================================
 # verify-image step Tests
 # ============================================================================


### PR DESCRIPTION
### Description

This PR fixes an issue with the CVE remediation updater GHA: if a `-env` suffixed version is found, it might include it. This PR filters those out so the correct version can be chosen.

Related #TRNT-4408

### How was this tested?

CI

### Documentation changes

No

### Additional information

This should prevent PRs like https://github.com/trento-project/helm-charts/pull/244 from being created.