### PR TITLE
Check differences in OBS branches in CI

### DIFF
--- a/.github/scripts/helm-upgrade-helper.sh
+++ b/.github/scripts/helm-upgrade-helper.sh
@@ -628,13 +628,13 @@ compare_obs_branches() {
 
   local tmp_diff
   tmp_diff="$(mktemp)"
-  trap 'rm -f "$tmp_diff"' RETURN
 
   local diff_rc=0
   diff -u "$stable_values" "$main_values" > "$tmp_diff" || diff_rc=$?
 
   if [ "$diff_rc" -eq 0 ]; then
     echo "✅ No differences between OBS stable and main branches"
+    rm -f "$tmp_diff"
     return 0
   fi
 
@@ -643,11 +643,13 @@ compare_obs_branches() {
     if [ -s "$tmp_diff" ]; then
       cat "$tmp_diff"
     fi
+    rm -f "$tmp_diff"
     return 2
   fi
 
   section "=== Differences found between OBS stable and main ==="
   cat "$tmp_diff"
+  rm -f "$tmp_diff"
   echo ""
   separator
   echo "NOTE: These differences may indicate that stable needs to be updated"

--- a/.github/scripts/helm-upgrade-helper.sh
+++ b/.github/scripts/helm-upgrade-helper.sh
@@ -608,7 +608,7 @@ process_obs_package() {
 # Compare OBS stable and main branches values.yaml
 # Args: $1 (string) - Path to stable branch values.yaml
 #       $2 (string) - Path to main branch values.yaml
-# Returns: 0 if identical, 1 if different
+# Returns: 0 if identical, 1 if different, 2 on error
 # Outputs: Formatted diff showing differences
 compare_obs_branches() {
   local stable_values="$1"
@@ -616,12 +616,12 @@ compare_obs_branches() {
 
   if [ ! -f "$stable_values" ]; then
     echo "ERROR: Stable values file not found: $stable_values" >&2
-    return 1
+    return 2
   fi
 
   if [ ! -f "$main_values" ]; then
     echo "ERROR: Main values file not found: $main_values" >&2
-    return 1
+    return 2
   fi
 
   banner "           Comparing OBS stable vs main branch values.yaml             "
@@ -643,7 +643,7 @@ compare_obs_branches() {
     if [ -s "$tmp_diff" ]; then
       cat "$tmp_diff"
     fi
-    return 1
+    return 2
   fi
 
   section "=== Differences found between OBS stable and main ==="

--- a/.github/scripts/helm-upgrade-helper.sh
+++ b/.github/scripts/helm-upgrade-helper.sh
@@ -72,7 +72,6 @@ show_events() {
 # Args: $1 (string, optional) - Number of log lines per pod (default: 30, 0 for all)
 #       $2 (string, optional) - Context prefix for section header (e.g., "Recent ")
 #       $3 (string, optional) - Whether to show previous container logs (default: false)
-#       $4 (string, optional) - Custom separator line
 # Uses: TRENTO_NAMESPACE environment variable
 # Outputs: Pod logs for each container
 show_pod_logs() {
@@ -628,21 +627,31 @@ compare_obs_branches() {
   banner "           Comparing OBS stable vs main branch values.yaml             "
 
   local tmp_diff
-  tmp_diff=$(mktemp)
+  tmp_diff="$(mktemp)"
+  trap 'rm -f "$tmp_diff"' RETURN
 
-  if diff -u "$stable_values" "$main_values" > "$tmp_diff"; then
+  local diff_rc=0
+  diff -u "$stable_values" "$main_values" > "$tmp_diff" || diff_rc=$?
+
+  if [ "$diff_rc" -eq 0 ]; then
     echo "✅ No differences between OBS stable and main branches"
-    rm -f "$tmp_diff"
     return 0
-  else
-    section "=== Differences found between OBS stable and main ==="
-    cat "$tmp_diff"
-    echo ""
-    separator
-    echo "NOTE: These differences may indicate that stable needs to be updated"
-    rm -f "$tmp_diff"
+  fi
+
+  if [ "$diff_rc" -ne 1 ]; then
+    echo "ERROR: diff failed (exit $diff_rc) while comparing $stable_values and $main_values" >&2
+    if [ -s "$tmp_diff" ]; then
+      cat "$tmp_diff"
+    fi
     return 1
   fi
+
+  section "=== Differences found between OBS stable and main ==="
+  cat "$tmp_diff"
+  echo ""
+  separator
+  echo "NOTE: These differences may indicate that stable needs to be updated"
+  return 1
 }
 
 main() {

--- a/.github/scripts/helm-upgrade-helper.sh
+++ b/.github/scripts/helm-upgrade-helper.sh
@@ -31,6 +31,12 @@ banner() {
   printf '%s\n' "╚════════════════════════════════════════════════════════════════════════╝"
 }
 
+# Print a separator line.
+separator() {
+  printf '─%.0s' {1..72}
+  printf '\n'
+}
+
 # === Kubernetes Diagnostics ===
 
 # Display status of all pods and highlight non-running pods.
@@ -73,15 +79,13 @@ show_pod_logs() {
   local log_lines="${1:-30}"
   local log_context="${2:-}"
   local show_previous="${3:-false}"
-  local separator="${4:-────────────────────────────────────────────────────────────────────────}"
-
   section "=== ${log_context}Pod logs (last $log_lines lines each) ==="
   local pod
   for pod in $(kubectl get pods -n "$TRENTO_NAMESPACE" -o jsonpath='{.items[*].metadata.name}'); do
     echo ""
-    echo "$separator"
+    separator
     echo "Pod: $pod"
-    echo "$separator"
+    separator
     kubectl logs -n "$TRENTO_NAMESPACE" "$pod" --all-containers=true --tail="$log_lines" --ignore-errors=true || echo "No logs available"
 
     if [ "$show_previous" = "true" ]; then
@@ -102,9 +106,9 @@ show_failed_pod_logs() {
   if [ -n "$failed_pods" ]; then
     for pod in $failed_pods; do
       echo ""
-      echo "────────────────────────────────────────────────────────────────────────"
+      separator
       echo "Pod: $pod (last 100 lines)"
-      echo "────────────────────────────────────────────────────────────────────────"
+      separator
       kubectl logs -n "$TRENTO_NAMESPACE" "$pod" --all-containers=true --tail=100 --ignore-errors=true || echo "No logs available"
     done
   else
@@ -150,7 +154,7 @@ compare_versions() {
     if [ "$chart_name" != "$current_chart" ]; then
       if [ -n "$current_chart" ]; then echo ""; fi
       echo "📦 Chart: ${chart_name}"
-      echo "────────────────────────────────────────────────────────────────────────"
+      separator
       current_chart="$chart_name"
     fi
 
@@ -182,7 +186,7 @@ compare_versions() {
   done < "$new_images_file"
 
   echo ""
-  echo "────────────────────────────────────────────────────────────────────────"
+  separator
 }
 
 # Extract and compare container versions between deployed pods and Helm chart.

--- a/.github/scripts/helm-upgrade-helper.sh
+++ b/.github/scripts/helm-upgrade-helper.sh
@@ -606,6 +606,45 @@ process_obs_package() {
   return 0
 }
 
+# Compare OBS stable and main branches values.yaml
+# Args: $1 (string) - Path to stable branch values.yaml
+#       $2 (string) - Path to main branch values.yaml
+# Returns: 0 if identical, 1 if different
+# Outputs: Formatted diff showing differences
+compare_obs_branches() {
+  local stable_values="$1"
+  local main_values="$2"
+
+  if [ ! -f "$stable_values" ]; then
+    echo "ERROR: Stable values file not found: $stable_values" >&2
+    return 1
+  fi
+
+  if [ ! -f "$main_values" ]; then
+    echo "ERROR: Main values file not found: $main_values" >&2
+    return 1
+  fi
+
+  banner "           Comparing OBS stable vs main branch values.yaml             "
+
+  local tmp_diff
+  tmp_diff=$(mktemp)
+
+  if diff -u "$stable_values" "$main_values" > "$tmp_diff"; then
+    echo "✅ No differences between OBS stable and main branches"
+    rm -f "$tmp_diff"
+    return 0
+  else
+    section "=== Differences found between OBS stable and main ==="
+    cat "$tmp_diff"
+    echo ""
+    separator
+    echo "NOTE: These differences may indicate that stable needs to be updated"
+    rm -f "$tmp_diff"
+    return 1
+  fi
+}
+
 main() {
   case "${1:-}" in
     post-install-diagnostics)
@@ -627,6 +666,10 @@ main() {
       shift
       process_obs_package "$@"
       ;;
+    compare-obs-branches)
+      shift
+      compare_obs_branches "$@"
+      ;;
     *)
       printf '%s\n' "Usage: upgrade-test.sh <command>" >&2
       printf '%s\n' "" >&2
@@ -637,6 +680,7 @@ main() {
       printf '%s\n' "  verify-api" >&2
       printf '%s\n' "  failure-diagnostics" >&2
       printf '%s\n' "  process-obs-package <git-url> [workspace-dir]" >&2
+      printf '%s\n' "  compare-obs-branches <stable-values> <main-values>" >&2
       exit 1
       ;;
   esac

--- a/.github/scripts/tests/helm-upgrade-helper.bats
+++ b/.github/scripts/tests/helm-upgrade-helper.bats
@@ -1265,3 +1265,71 @@ EOF
   # Should trim whitespace
   [[ "$output" == *"values.yaml"* ]]
 }
+
+# === OBS Branch Comparison Tests ===
+
+@test "compare_obs_branches: returns 0 when files are identical" {
+  stable_values="$TEST_TMP/stable-values.yaml"
+  main_values="$TEST_TMP/main-values.yaml"
+
+  cat > "$stable_values" << 'EOF'
+trento-web:
+  image:
+    repository: registry.suse.com/trento/trento-web
+trento-wanda:
+  checks:
+    image:
+      repository: registry.suse.com/trento/trento-checks
+EOF
+
+  cp "$stable_values" "$main_values"
+
+  run compare_obs_branches "$stable_values" "$main_values"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No differences"* ]]
+}
+
+@test "compare_obs_branches: returns 1 when files differ" {
+  stable_values="$TEST_TMP/stable-values.yaml"
+  main_values="$TEST_TMP/main-values.yaml"
+
+  cat > "$stable_values" << 'EOF'
+trento-wanda:
+  checks:
+    image:
+      repository: registry.suse.com/trento/checks
+EOF
+
+  cat > "$main_values" << 'EOF'
+trento-wanda:
+  checks:
+    image:
+      repository: registry.suse.com/trento/trento-checks
+EOF
+
+  run compare_obs_branches "$stable_values" "$main_values"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Differences found"* ]]
+  [[ "$output" == *"trento/checks"* ]]
+  [[ "$output" == *"trento/trento-checks"* ]]
+}
+
+@test "compare_obs_branches: returns error when stable file missing" {
+  main_values="$TEST_TMP/main-values.yaml"
+  echo "test" > "$main_values"
+
+  run compare_obs_branches "/nonexistent/file" "$main_values"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR"* ]]
+  [[ "$output" == *"Stable values file not found"* ]]
+}
+
+@test "compare_obs_branches: returns error when main file missing" {
+  stable_values="$TEST_TMP/stable-values.yaml"
+  echo "test" > "$stable_values"
+
+  run compare_obs_branches "$stable_values" "/nonexistent/file"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR"* ]]
+  [[ "$output" == *"Main values file not found"* ]]
+}

--- a/.github/scripts/tests/helm-upgrade-helper.bats
+++ b/.github/scripts/tests/helm-upgrade-helper.bats
@@ -1319,7 +1319,7 @@ EOF
   echo "test" > "$main_values"
 
   run compare_obs_branches "/nonexistent/file" "$main_values"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 2 ]
   [[ "$output" == *"ERROR"* ]]
   [[ "$output" == *"Stable values file not found"* ]]
 }
@@ -1329,7 +1329,7 @@ EOF
   echo "test" > "$stable_values"
 
   run compare_obs_branches "$stable_values" "/nonexistent/file"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 2 ]
   [[ "$output" == *"ERROR"* ]]
   [[ "$output" == *"Main values file not found"* ]]
 }

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -117,13 +117,16 @@ jobs:
       - name: Compare OBS stable vs main branches
         if: matrix.source == env.SOURCE_OBS_ARTIFACTS
         run: |
+          obs_stable_dir="$(mktemp -d)"
+          trap 'rm -rf "$obs_stable_dir"' EXIT
+
           echo "Cloning OBS stable branch for comparison..."
           git clone --branch stable --depth 1 \
-            https://src.opensuse.org/SAP-trento/trento-server-helm.git /tmp/obs-stable
+            https://src.opensuse.org/SAP-trento/trento-server-helm.git "$obs_stable_dir"
 
           # Run comparison and capture exit code
           if ! bash .github/scripts/helm-upgrade-helper.sh compare-obs-branches \
-            /tmp/obs-stable/values.yaml \
+            "$obs_stable_dir/values.yaml" \
             obs-artifacts/chart/values.yaml; then
             echo "::notice title=OBS Branch Drift Detected::Differences found between OBS stable and main branches. The stable branch may need to be updated with changes from main. See the comparison output above for details."
           fi

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -114,6 +114,20 @@ jobs:
 
           echo "OBS artifacts processed successfully"
 
+      - name: Compare OBS stable vs main branches
+        if: matrix.source == env.SOURCE_OBS_ARTIFACTS
+        run: |
+          echo "Cloning OBS stable branch for comparison..."
+          git clone --branch stable --depth 1 \
+            https://src.opensuse.org/SAP-trento/trento-server-helm.git /tmp/obs-stable
+
+          # Run comparison and capture exit code
+          if ! bash .github/scripts/helm-upgrade-helper.sh compare-obs-branches \
+            /tmp/obs-stable/values.yaml \
+            obs-artifacts/chart/values.yaml; then
+            echo "::notice title=OBS Branch Drift Detected::Differences found between OBS stable and main branches. The stable branch may need to be updated with changes from main. See the comparison output above for details."
+          fi
+
       - name: Prepare OBS upstream chart for installation
         if: matrix.source == env.SOURCE_OBS_ARTIFACTS
         run: |

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -125,10 +125,15 @@ jobs:
             https://src.opensuse.org/SAP-trento/trento-server-helm.git "$obs_stable_dir"
 
           # Run comparison and capture exit code
-          if ! bash .github/scripts/helm-upgrade-helper.sh compare-obs-branches \
+          rc=0
+          bash .github/scripts/helm-upgrade-helper.sh compare-obs-branches \
             "$obs_stable_dir/values.yaml" \
-            obs-artifacts/chart/values.yaml; then
+            obs-artifacts/chart/values.yaml || rc=$?
+
+          if [ "$rc" -eq 1 ]; then
             echo "::notice title=OBS Branch Drift Detected::Differences found between OBS stable and main branches. The stable branch may need to be updated with changes from main. See the comparison output above for details."
+          elif [ "$rc" -ne 0 ]; then
+            exit "$rc"
           fi
 
       - name: Prepare OBS upstream chart for installation


### PR DESCRIPTION
### Description

Recently, we noticed a bug in our helm chart due to a mismatch between the branches used in OBS. Whereas the root cause (missing backported PR) cannot be prevented by this PR, at least, it aims at making the debugging process easier.

This PR just adds a diff comparison between branches in OBS, so that we can easily notice the differences.

<img width="749" height="61" alt="image" src="https://github.com/user-attachments/assets/5e7bb01f-fe74-469c-9b2f-c4a3cd984080" />


Related #TRNT-4408

### How was this tested?

CI

### Documentation changes

No

### Additional information

We could, potentially, add yet another test case for testing the `stable` branch. This would allow us to catch similar issues from the moment a release is created, but it has not been approved by our maintenance team yet (=therefore, it is unreleased at registry.suse.com). But... seems to much of an overkill here. See what you think, though.