### PR TITLE
Filter out "-env"-containing tags from CVE remediation

### DIFF
--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -187,8 +187,8 @@ find_compatible_upgrade() {
       continue
     fi
 
-    # Skip internal testing tags with -env suffix (e.g., "720-env")
-    if [[ "$tag" =~ -env$ ]]; then
+    # Skip internal testing tags containing -env as a segment (e.g., "720-env", "3501-env-prod")
+    if [[ "$tag" =~ -env($|-) ]]; then
       continue
     fi
 

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -240,8 +240,8 @@ setup() {
 @test "find_compatible_upgrade: skips internal -env tags" {
   # Current: 2.0.0
   # Available: internal -env tags, valid versions
-  # Should return: 2.1.0 (skips 720-env, 718-env)
-  local tags=("720-env" "2.1.0" "718-env" "2.0.0")
+  # Should return: 2.1.0 (skips 720-env, 718-env, 3501-env-prod)
+  local tags=("720-env" "2.1.0" "718-env" "3501-env-prod" "2.0.0")
   local result
   result=$(find_compatible_upgrade "2.0.0" "${tags[@]}")
 
@@ -250,9 +250,9 @@ setup() {
 
 @test "find_compatible_upgrade: returns empty when only -env tags are newer" {
   # Current: 2.0.0
-  # Available: 720-env, 718-env (newer but -env), 2.0.0 (equal, not an upgrade)
+  # Available: 720-env, 718-env, 3501-env-prod (all -env variants, filtered), 2.0.0 (equal, not an upgrade)
   # Should return: empty (-env tags must never be selected as upgrade target)
-  local tags=("720-env" "718-env" "2.0.0")
+  local tags=("720-env" "718-env" "3501-env-prod" "2.0.0")
   local result
   result=$(find_compatible_upgrade "2.0.0" "${tags[@]}")
 


### PR DESCRIPTION
### Description

This PR, following up on #245,  fixes an issue with the CVE remediation updater GHA: if a version containing `-env` is found, it might include it. This PR filters those out so the correct version can be chosen.

While the previous PR assumed this `-env` was only a suffix, doing `skopeo list-tags docker://ghcr.io/trento-project/trento-web` revealed otherwise. Hopefully, this fix should work...

Related #TRNT-4408

### How was this tested?

CI

### Documentation changes

No

### Additional information

This should prevent PRs like https://github.com/trento-project/helm-charts/pull/247 from being created.