### PR TITLE
Update busybox and kubectl images to BCI

### DIFF
--- a/charts/trento-server/charts/trento-wanda/templates/tests/test-connection.yaml
+++ b/charts/trento-server/charts/trento-wanda/templates/tests/test-connection.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: registry.suse.com/bci/bci-busybox:16.0
       command: ['wget']
       args: ['{{ include "trento-wanda.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/trento-server/charts/trento-web/templates/tests/test-web-connection.yaml
+++ b/charts/trento-server/charts/trento-web/templates/tests/test-web-connection.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: registry.suse.com/bci/bci-busybox:16.0
       command: ['wget']
       args: ['{{ include "trento-web.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/trento-server/templates/cert-manager-resources.yaml
+++ b/charts/trento-server/templates/cert-manager-resources.yaml
@@ -92,7 +92,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: wait
-        image: registry.k8s.io/kubectl:v1.33.3
+        image: {{ .Values.rabbitmq.certWaiter.image.registry }}/{{ .Values.rabbitmq.certWaiter.image.repository }}:{{ .Values.rabbitmq.certWaiter.image.tag }}
         command:
         - kubectl
         - wait

--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -151,9 +151,9 @@ prometheus:
 
   migrationHook:
     image:
-      registry: registry.k8s.io
-      repository: kubectl
-      tag: v1.33.3
+      registry: registry.suse.com
+      repository: suse/kubectl
+      tag: "1.35"
 
 rabbitmq:
   enabled: true
@@ -161,6 +161,12 @@ rabbitmq:
     enabled: true
   service:
     type: LoadBalancer
+
+  certWaiter:
+    image:
+      registry: registry.suse.com
+      repository: suse/kubectl
+      tag: "1.35"
 
   extraConfiguration: |
     {{- if .Values.global.rabbitmq.tls.mtls.enabled }}


### PR DESCRIPTION
Backport of #203 for the 3.1.2 patch release.