### PR TITLE
[CVE Fix] Update kubectl to 1.35.4

### DIFF
--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -153,8 +153,7 @@ prometheus:
     image:
       registry: registry.suse.com
       repository: suse/kubectl
-      tag: "1.35"
-
+      tag: "1.35.4"
 rabbitmq:
   enabled: true
   persistence:
@@ -166,8 +165,7 @@ rabbitmq:
     image:
       registry: registry.suse.com
       repository: suse/kubectl
-      tag: "1.35"
-
+      tag: "1.35.4"
   extraConfiguration: |
     {{- if .Values.global.rabbitmq.tls.mtls.enabled }}
     listeners.ssl.default = 5671


### PR DESCRIPTION
Backport of #259 for the 3.1.3 patch release.