### PR TITLE
[CVE Fix] Update trento-web to 3.1.5

### DIFF
--- a/charts/trento-server/charts/trento-web/Chart.yaml
+++ b/charts/trento-server/charts/trento-web/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.2
+version: 3.1.5

--- a/charts/trento-server/charts/trento-web/values.yaml
+++ b/charts/trento-server/charts/trento-web/values.yaml
@@ -88,7 +88,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/trento-project/trento-web
   pullPolicy: IfNotPresent
-  tag: 3.1.2
+  tag: 3.1.5
 
 postgresql:
   image:


### PR DESCRIPTION
Backport of #258 for the 3.1.3 patch release.