### PR TITLE
[CVE Fix] Update prometheus to v3.13.1

### DIFF
--- a/charts/trento-server/values.yaml
+++ b/charts/trento-server/values.yaml
@@ -81,7 +81,7 @@ prometheus:
   server:
     enabled: true
     image:
-      tag: v2.53.1
+      tag: v3.13.1
     configMapOverrideName: prometheus-configmap
     prefixURL: "/prometheus"
     baseURL: "/prometheus"


### PR DESCRIPTION
Backport of #252 for the 3.1.3 patch release.