### PR TITLE
Fix wrong CI error when branch exists

### DIFF
--- a/.github/scripts/cve-scan-helper-remediation.sh
+++ b/.github/scripts/cve-scan-helper-remediation.sh
@@ -1083,9 +1083,8 @@ manage_pr() {
   log_info "Using branch: $branch_name"
 
   if branch_exists_on_remote "$branch_name"; then
-    local branch_inspection_status
-    remote_branch_has_manual_commits "$branch_name"
-    branch_inspection_status=$?
+    local branch_inspection_status=0
+    remote_branch_has_manual_commits "$branch_name" || branch_inspection_status=$?
 
     if [ "$branch_inspection_status" -eq 0 ]; then
       log_warning "Branch already exists remotely with manual changes - skipping to preserve manual changes"
@@ -1138,9 +1137,8 @@ manage_pr() {
   cve_count=$(jq '.cves | length' "$analysis_file")
   commit_msg=$(build_commit_message "$image_name" "$target_tag" "$cve_count")
 
-  local stage_result
-  stage_and_commit "$updated_files" "$commit_msg" "$branch_name"
-  stage_result=$?
+  local stage_result=0
+  stage_and_commit "$updated_files" "$commit_msg" "$branch_name" || stage_result=$?
 
   if [ "$stage_result" -eq 2 ]; then
     local output_json

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -552,7 +552,7 @@ MOCKEOF
 
   run bash -c "
     set -euo pipefail
-    export PATH='$FIXTURES_DIR:\$PATH' GH_TOKEN=dummy
+    export PATH='$FIXTURES_DIR:$PATH' GH_TOKEN=dummy
     cd '$FIXTURES_DIR'
     source '$SCRIPT_DIR/helpers.sh'
     source '$SCRIPT_DIR/cve-scan-helper-remediation.sh'

--- a/.github/scripts/tests/cve-scan-helper-remediation.bats
+++ b/.github/scripts/tests/cve-scan-helper-remediation.bats
@@ -519,6 +519,53 @@ EOF
   rm -rf "$tmpdir"
 }
 
+@test "manage_pr: don't error when a remote branch exists already" {
+  local target_tag="1.2.3"
+  local branch_name
+  branch_name=$(generate_branch_name "test-image" "$target_tag")
+
+  # Fake git: branch already exists remotely with one automation-only commit.
+  cat > "$FIXTURES_DIR/git" << MOCKEOF
+#!/usr/bin/env bash
+case "\$1" in
+  ls-remote) echo "0000000000000000000000000000000000000000 refs/heads/$branch_name" ;;
+  log) printf 'trentobot|trentobot@suse.com\n' ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$FIXTURES_DIR/git"
+
+  # Fake gh: just enough for validate_gh_prerequisites to pass.
+  cat > "$FIXTURES_DIR/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+[ "$1" = "auth" ] && exit 0
+exit 1
+MOCKEOF
+  chmod +x "$FIXTURES_DIR/gh"
+
+  # No updated files, so manage_pr short-circuits to "no_changes" right
+  # after the branch-reuse logic - no push/PR-create mocking needed.
+  echo "{\"image_ref\": \"docker.io/test-image:1.0.0\", \"base_image\": \"docker.io/test-image\", \"current_tag\": \"1.0.0\", \"cves\": []}" \
+    > "$FIXTURES_DIR/image-analysis.json"
+  echo "{\"target_tag\": \"$target_tag\"}" > "$FIXTURES_DIR/upgrade-plan.json"
+  echo '{"updated_files": []}' > "$FIXTURES_DIR/values-updates.json"
+
+  run bash -c "
+    set -euo pipefail
+    export PATH='$FIXTURES_DIR:\$PATH' GH_TOKEN=dummy
+    cd '$FIXTURES_DIR'
+    source '$SCRIPT_DIR/helpers.sh'
+    source '$SCRIPT_DIR/cve-scan-helper-remediation.sh'
+    manage_pr image-analysis.json upgrade-plan.json values-updates.json pr-result.json
+    echo SURVIVED
+  " 2>&1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Reusing existing automation branch"* ]]
+  [[ "$output" == *"SURVIVED"* ]]
+  [ "$(jq -r '.action_taken' "$FIXTURES_DIR/pr-result.json")" = "no_changes" ]
+}
+
 @test "query_code_scanning_alerts: filters out non-CVE rules" {
   # Mock gh command that properly handles --jq flag
   # shellcheck disable=SC2329


### PR DESCRIPTION
### Description

The CVE remediation is failing whenever it tries to reuse an already-existing branch — e.g. when a previous CVE-fix PR for the same image/tag is still open.
Example failure: [run 30876030827](https://github.com/trento-project/helm-charts/actions/runs/30876030827/job/91887833160), branch cve-fix/rabbitmq-4.3.4-management-alpine.

This is because, in `manage_pr()`, the exit code was captured in a way that fails under `set -euo pipefail`. 

This PR is capturing the exit code using the standard `cmd || var=$?` idiom, which keeps the whole statement's exit status at 0 (since the assignment always succeeds) so set -e has nothing to trip on:


### How was this tested?

Added a regression test that mocks git/gh to simulate an existing automation-only remote branch and runs manage_pr as a real subprocess with set -e active (mirroring production).

### Documentation changes

No

### Additional information

N/A